### PR TITLE
set process-connection-type to nil, to fix issue with gvfs-open

### DIFF
--- a/mime-play.el
+++ b/mime-play.el
@@ -156,7 +156,8 @@ specified, play as it.  Default MODE is \"play\"."
 		  (mime-format-mailcap-command
 		   method
 		   (cons (cons 'filename name) situation)))
-		 (coding-system-for-read mime-play-messages-coding-system))
+		 (coding-system-for-read mime-play-messages-coding-system)
+                 (process-connection-type nil))
 	     (start-process command mime-echo-buffer-name
 	      shell-file-name shell-command-switch command))))
       (set-alist 'mime-mailcap-method-filename-alist process name)


### PR DESCRIPTION
This fixes the issues described here:
- https://bugzilla.gnome.org/show_bug.cgi?id=652262
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=741651

and should have no effect on other programs.
