### PR TITLE
Use default parameter in completing-read

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2016-02-24  Erik Hetzner  <egh@e6h.org>
+
+	* mime-edit.el (mime-prompt-for-type, mime-prompt-for-type)
+	(mime-prompt-for-encoding): Use default parameter to set default
+	answer.
+	(mime-prompt-for-encoding): Make default optional.
+	(mime-edit-insert-voice): Use `mime-prompt-for-encoding' to prompt
+	user for encoding.
+
 2016-02-04  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	User is now prompted whether proceed PGP/MIME encryption when

--- a/mime-edit.el
+++ b/mime-edit.el
@@ -1627,10 +1627,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 (defun mime-edit-insert-voice ()
   "Insert a voice message."
   (interactive)
-  (let ((encoding
-	 (completing-read
-	  "What transfer encoding: "
-	  (mime-encoding-alist) nil t nil)))
+  (let ((encoding (mime-prompt-for-encoding)))
     (mime-edit-insert-tag "audio" "basic" nil)
     (mime-edit-define-encoding encoding)
     (save-restriction
@@ -1972,8 +1969,9 @@ Nil if no such parameter."
 			     mime-content-types
 			     nil
 			     'require-match ;Type must be specified.
-			     default
-			     ))
+			     nil
+			     nil
+			     default))
       (if (string-equal type "")
 	  (progn
 	    (message "Content type is required.")
@@ -2000,7 +1998,8 @@ Nil if no such parameter."
 	   nil
 	   'require-match		;Subtype must be specified.
 	   nil
-	   )))
+	   nil
+	   default)))
     (if (string-equal answer "") default answer)))
 
 (defun mime-prompt-for-parameters (pritype subtype &optional delimiter)
@@ -2059,15 +2058,19 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
 	  (mime-prompt-for-parameters-1 (cdr (assoc answer (cdr parameter)))))
     ))
 
-(defun mime-prompt-for-encoding (default)
+(defun mime-prompt-for-encoding (&optional default)
   "Ask for Content-Transfer-Encoding."
   (let (encoding)
     (while (string=
 	    (setq encoding
 		  (completing-read
 		   "What transfer encoding: "
-		   (mime-encoding-alist) nil t default)
-		  )
+		   (mime-encoding-alist)
+		   nil
+		   t
+		   nil
+		   nil
+		   default))
 	    ""))
     encoding))
 


### PR DESCRIPTION
mime-edit.el (mime-prompt-for-type, mime-prompt-for-type)
(mime-prompt-for-encoding): Use default parameter to set default
answer.
(mime-prompt-for-encoding): Make default optional.
(mime-edit-insert-voice): Use `mime-prompt-for-encoding' to prompt
user for encoding.

Using the `default` parameter means that defaults should work better if `completing-read' use ido, and possibly helm or other similar packages.

Without this fix, when using the `ido-ubiquitous` package, ido would return different values than what the default was supposed to be. For instance, I would receive the prompt `What content subtype: (default pdf)` and, if I hit enter, ido would select `javascript`.
