### PR TITLE
Add dir entry to mime-ui-{en,ja}.texi

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-08-14  Erik Hetzner  <egh@e6h.org>
+
+	* mime-ui-en.texi: Add dir entry
+
+	* mime-ui-ja.texi: Likewise
+
 2016-07-01  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* mime-tnef.el (mime-tnef-files): Fix corrupt result.

--- a/mime-ui-en.texi
+++ b/mime-ui-en.texi
@@ -1,6 +1,13 @@
 \input texinfo.tex
 @setfilename mime-ui-en.info
 @settitle SEMI 1.14 Manual
+@documentlanguage en
+
+@dircategory GNU Emacs Lisp
+@direntry
+* SEMI (en): (mime-ui-en).      MIME user interface.
+@end direntry
+
 @titlepage
 @title SEMI 1.14 Manual
 @author MORIOKA Tomohiko <morioka@@jaist.ac.jp>

--- a/mime-ui-ja.texi
+++ b/mime-ui-ja.texi
@@ -2,6 +2,12 @@
 @setfilename mime-ui-ja.info
 @documentencoding iso-2022-jp
 @documentlanguage ja
+
+@dircategory GNU Emacs Lisp
+@direntry
+* SEMI (ja): (mime-ui-ja).      MIME user interface.
+@end direntry
+
 @settitle SEMI 1.14 説明書
 @titlepage
 @title SEMI 1.14 説明書


### PR DESCRIPTION
This will allow `install-info` to work, which will enable proper installation of the documentation via MELPA.

You can test as follows:

```
makeinfo *.texi 
install-info --dir=dir mime-ui-en.info 
install-info --dir=dir mime-ui-ja.info 
cp dir ~/.emacs.d/elpa/semi-20160701.440/dir # or wherever you have semi installed as a package
```
