### PR TITLE
Add library semi.el whose name matches that of the package semi

### DIFF
--- a/semi.el
+++ b/semi.el
@@ -1,0 +1,33 @@
+;;; semi.el --- MIME features
+
+;; Copyright (C) 1996-2017  Free Software Foundation, Inc.
+
+;; Author: MORIOKA Tomohiko <tomo@m17n.org>
+;; Keywords: MIME, multimedia, mail, news
+
+;; This file is part of SEMI (Setting for Emacs MIME Interfaces).
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; SEMI (Setting for Emacs MIME Interfaces) provides MIME features.
+
+;;; Code:
+
+(provide 'semi)
+
+;;; semi.el ends here


### PR DESCRIPTION
A package should always contain a library with the same name.
One benefit of that is that Melpa can then extract the package
description from the library commentary.