### PR TITLE
Don't fail when XEmacs without MULE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-07-07  Tatsuya Kinoshita  <tats@debian.org>
+
+	* mime-view.el (mime-display-multipart/multilingual-prefered-languages):
+	Check for `get-language-info' existence.
+
 2019-06-26  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* mime-image.el (mime-image-create): Update native image scaling

--- a/mime-view.el
+++ b/mime-view.el
@@ -97,8 +97,10 @@ multipart/alternative entities."
 (defcustom mime-display-multipart/multilingual-prefered-languages
   (mapcar (lambda (lang)
 	    (format "^%s\\(-.+\\)?" (regexp-quote (symbol-name lang))))
-	  (let ((result (get-language-info
-			 current-language-environment 'iso639-language)))
+	  (let ((result (if (fboundp 'get-language-info)
+			    (get-language-info
+			     current-language-environment 'iso639-language)
+			  'en)))
 	    (if (eq result 'en)
 		(list result)
 	      (cons result '(en)))))


### PR DESCRIPTION
XEmacs without MULE fails with this error:

```
  !! Symbol's function definition is void ((get-language-info))
```

So added the existence check.
