### PR TITLE
Check emacs-build-number for mime-edit-user-agent-value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-04-28  Tatsuya Kinoshita  <tats@debian.org>
+
+	* mime-edit.el (mime-edit-user-agent-value): Check for
+	emacs-build-number existence to handle emacs-version correctly.
+
 2020-04-13  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* mime-image.el (mime-image-max-width, mime-image-max-height):

--- a/mime-edit.el
+++ b/mime-edit.el
@@ -1049,7 +1049,8 @@ If it is not specified for a major-mode,
 			   " ("
 			   system-configuration ")")
 			" (" emacs-version ")"))
-	    (let ((ver (if (string-match "\\.[0-9]+$" emacs-version)
+	    (let ((ver (if (and (not (boundp 'emacs-build-number))
+				(string-match "\\.[0-9]+$" emacs-version))
 			   (substring emacs-version 0 (match-beginning 0))
 			 emacs-version)))
 	      (if (featurep 'mule)


### PR DESCRIPTION
Currently, mime-edit-user-agent-value includes
"Emacs/26", "Emacs/27.0", "Emacs/28.0" for Emacs 26.3, 27.0.91, 28.0.50.

Expected behavior is "Emacs/26.3", "Emacs/27.0.91", "Emacs/28.0.50".

cf. http://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS.26#n300

> ** The variable 'emacs-version' no longer includes the build number.
> This is now stored separately in a new variable, 'emacs-build-number'.
