### PR TITLE
use ?\s instead of ?(whitespace)

### DIFF
--- a/mime-image.el
+++ b/mime-image.el
@@ -201,7 +201,7 @@ Furthermore, image scaling for xbm image is disabled."
 	(let ((face (gensym "mii")))
 	  (or (facep face) (make-face face))
 	  (set-face-stipple face image)
-	  (let ((row (make-string (/ (car image)  (frame-char-width)) ? ))
+	  (let ((row (make-string (/ (car image)  (frame-char-width)) ?\s))
 		(height (/ (nth 1 image)  (frame-char-height)))
 		(i 0))
 	    (while (< i height)


### PR DESCRIPTION
? and ?\ and ?\s are return same value.
?\s is easier to read and understand.

```elisp
(list ?  ?\  ?\s)
;;=> (32 32 32)
```
ref: https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Basic-Char-Syntax