### PR TITLE
fix closing parens position

### DIFF
--- a/mail-mime-setup.el
+++ b/mail-mime-setup.el
@@ -44,16 +44,14 @@
 (set-alist 'mime-edit-split-message-sender-alist
            'mail-mode (lambda ()
                         (interactive)
-                        (funcall send-mail-function)
-                        ))
+                        (funcall send-mail-function)))
 
 
 ;;; @ for signature
 ;;;
 
 (if mime-setup-use-signature
-    (setq mail-signature nil)
-  )
+    (setq mail-signature nil))
 
 
 ;;; @ end

--- a/mime-edit.el
+++ b/mime-edit.el
@@ -222,11 +222,9 @@ To insert a signature file automatically, call the function
        ("mail-server"
 	("server" "ftpmail@nic.karrn.ad.jp")
 	("subject"))
-       ("url"         ("url"))
-       ))
+       ("url"         ("url"))))
      ("rfc822")
-     ("news")
-     )
+     ("news"))
     ("application"
      ("javascript")
      ("msword")
@@ -321,52 +319,44 @@ To insert a signature file automatically, call the function
        ("\\.cc$"
 	"application" "octet-stream" (("type" . "C++") ("charset" . charset))
 	"7bit"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ("\\.el$"
 	"application" "octet-stream" (("type" . "emacs-lisp") ("charset" . charset))
 	"7bit"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ("\\.lsp$"
 	"application" "octet-stream" (("type" . "common-lisp") ("charset" . charset))
 	"7bit"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ("\\.pl$"
 	"application" "octet-stream" (("type" . "perl") ("charset" . charset))
 	"7bit"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ;; Text or translated text
 
        ("\\.txt$\\|\\.pln$"
 	"text"	"plain"		(("charset" . charset))
 	nil
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ("\\.css$"
 	"text"	"css"		(("charset" . charset))
 	nil
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ("\\.csv$"
 	"text"	"csv"		(("charset" . charset))
 	nil
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ("\\.tex$\\|\\.latex$"
 	"text"	"x-latex"	(("charset" . charset))
 	nil
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ;; .rc : procmail modules pm-xxxx.rc
        ;; *rc : other resource files
@@ -374,8 +364,7 @@ To insert a signature file automatically, call the function
        ("\\.\\(rc\\|lst\\|log\\|sql\\|mak\\)$\\|\\..*rc$"
 	"text"	"plain"		(("charset" . charset))
 	nil
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ("\\.html$"
 	"text"	"html"		(("charset" . charset))
@@ -385,8 +374,7 @@ To insert a signature file automatically, call the function
        ("\\.diff$\\|\\.patch$"
 	"application" "octet-stream" (("type" . "patch"))
 	nil
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ("\\.signature"
 	"text"	"plain"		(("charset" . charset))	nil	nil	nil)
@@ -395,22 +383,19 @@ To insert a signature file automatically, call the function
        ("\\.js$"
 	"application"	"javascript" (("charset" . charset))
 	nil
-	"inline"	nil
-	)
+	"inline"	nil)
 
        
        ("\\.vcf$"
 	"text"	"vcard"		(("charset" . "UTF-8"))
 	nil
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ;; Microsoft Project
        ("\\.mpp$"
 	"application" "vnd.ms-project" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        
        
        ;; Microsoft Office (none-OpenXML)
@@ -418,23 +403,19 @@ To insert a signature file automatically, call the function
        ("\\.rtf$"				; Rich text format
 	"application" "rtf" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.doc$"				;MS Word
 	"application" "msword" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xls$"				; MS Excel
 	"application" "vnd.ms-excel" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ppt$"				; MS Power Point
 	"application" "vnd.ms-powerpoint" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
 
        
        ;; Microsoft Office (OpenXML)
@@ -443,258 +424,210 @@ To insert a signature file automatically, call the function
        ("\\.docm$"
 	"application" "vnd.ms-word.document.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.docx$"
 	"application" "vnd.openxmlformats-officedocument.wordprocessingml.document" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.dotm$"
 	"application" "vnd.ms-word.template.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.dotx$"
 	"application" "vnd.openxmlformats-officedocument.wordprocessingml.template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        
                                         ; MS Power Point
        ("\\.potm$"
 	"application" "vnd.ms-powerpoint.template.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.potx$"
 	"application" "vnd.openxmlformats-officedocument.presentationml.template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ppam$"
 	"application" "vnd.ms-powerpoint.addin.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ppsm$"
 	"application" "vnd.ms-powerpoint.slideshow.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ppsx$"
 	"application" "vnd.openxmlformats-officedocument.presentationml.slideshow" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.pptm$"
 	"application" "vnd.ms-powerpoint.presentation.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.pptx$"
 	"application" "vnd.openxmlformats-officedocument.presentationml.presentation" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        
                                         ; MS Excel
        ("\\.xlam$"
 	"application" "vnd.ms-excel.addin.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xlsb$"
 	"application" "vnd.ms-excel.sheet.binary.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xlsm$"
 	"application" "vnd.ms-excel.sheet.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xlsx$"
 	"application" "vnd.openxmlformats-officedocument.spreadsheetml.sheet" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xltm$"
 	"application" "vnd.ms-excel.template.macroEnabled.12" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.xltx$"
 	"application" "vnd.openxmlformats-officedocument.spreadsheetml.template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        
        
        ;; Open Office
        ("\\.odt$"
 	"application" "vnd.oasis.opendocument.text" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ods$"
 	"application" "vnd.oasis.opendocument.spreadsheet" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.odg$"
 	"application" "vnd.oasis.opendocument.graphics" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.odf$"
 	"application" "vnd.oasis.opendocument.formula" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.odm$"
 	"application" "vnd.oasis.opendocument.text-master" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.odp$"
 	"application" "vnd.oasis.opendocument.presentation" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ott$"
 	"application" "vnd.oasis.opendocument.text-template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.ots$"
 	"application" "vnd.oasis.opendocument.spreadsheet-template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.otp$"
 	"application" "vnd.oasis.opendocument.presentation-template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        ("\\.otg$"
 	"application" "vnd.oasis.opendocument.graphics-template" nil
 	"base64"
-	"attachment" nil
-	)
+	"attachment" nil)
        
        ;; Postscript and PDF
        ("\\.ps$"
 	"application" "postscript"	nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.pdf$"
 	"application" "pdf"	nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ;;  Pure binary
 
        ("\\.jpg$\\|\\.jpeg$"
 	"image"	"jpeg"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.gif$"
 	"image"	"gif"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.png$"
 	"image"	"png"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.bmp$"
 	"image"	"bmp"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.svg$"
 	"image"	"svg+xml"   nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.tiff$"
 	"image"	"tiff"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.pic$"
 	"image"	"x-pic"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.mag$"
 	"image"	"x-mag"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.xbm$"
 	"image"	"x-xbm"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
        ("\\.xwd$"
 	"image"	"x-xwd"		nil
 	"base64"
-	"inline"		nil
-	)
+	"inline"		nil)
 
        ;; Audio and video
 
        ("\\.au$\\|\\.snd$"
 	"audio"	"basic"		nil
 	"base64"
-	"attachment"		nil
-	)
+	"attachment"		nil)
        ("\\.mp[234]\\|\\.m4[abp]$"
 	"audio"	"mpeg"		nil
 	"base64"
-	"attachment"		nil
-	)
+	"attachment"		nil)
        ("\\.ogg$"
 	"audio"	"ogg"		nil
 	"base64"
-	"attachment"		nil
-	)
+	"attachment"		nil)
        ("\\.ogg$"
 	"audio"	"vorbis"		nil
 	"base64"
-	"attachment"		nil
-	)
+	"attachment"		nil)
        ("\\.mpg\\|\\.mpeg$"
 	"video"	"mpeg"		nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.mp4\\|\\.m4v$"
 	"video"	"mp4"		nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.qt$\\|\\.mov$"
 	"video"	"quicktime"		nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.flv$"
 	"video"	"x-flv"		nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.swf$"
 	"application"	"x-shockwave-flash"		nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
 
        ;; Compressed files
@@ -702,62 +635,50 @@ To insert a signature file automatically, call the function
        ("\\.tar\\.gz$"
 	"application" "octet-stream" (("type" . "tar+gzip"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.tgz$"
 	"application" "octet-stream" (("type" . "tar+gzip"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.tar\\.Z$"
 	"application" "octet-stream" (("type" . "tar+compress"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.taz$"
 	"application" "octet-stream" (("type" . "tar+compress"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.gz$"
 	"application" "octet-stream" (("type" . "gzip"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.Z$"
 	"application" "octet-stream" (("type" . "compress"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.lzh$"
 	"application" "octet-stream" (("type" . "lha"))
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.zip$"
 	"application" "zip" nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("\\.7z$"
 	"application" "x-7z-compressed" nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
        ("winmail\\.dat$"
 	"application" "ms-tnef" nil
 	"base64"
-	"attachment"	nil
-	)
+	"attachment"	nil)
 
        ;; Rest
 
        (".*"
 	"application" "octet-stream" nil
 	nil
-	"attachment"	nil)
-       )
-     ))
+	"attachment"	nil))))
   "*Alist of file name, types, parameters, and default encoding.
 If encoding is nil, it is determined from its contents."
   :type `(repeat
@@ -765,8 +686,7 @@ If encoding is nil, it is determined from its contents."
 		;; primary-type
 		(choice :tag "Primary-Type"
 			,@(nconc (mapcar (lambda (cell)
-					   (list 'item (car cell))
-					   )
+					   (list 'item (car cell)))
 					 mime-content-types)
 				 '(string)))
 		;; subtype
@@ -775,8 +695,7 @@ If encoding is nil, it is determined from its contents."
 			   (apply #'nconc
 				  (mapcar (lambda (cell)
 					    (mapcar (lambda (cell)
-						      (list 'item (car cell))
-						      )
+						      (list 'item (car cell)))
 						    (cdr cell)))
 					  mime-content-types))
 			   '(string)))
@@ -788,8 +707,7 @@ If encoding is nil, it is determined from its contents."
 			,@(cons
 			   '(const nil)
 			   (mapcar (lambda (cell)
-				     (list 'item cell)
-				     )
+				     (list 'item cell))
 				   (mime-encoding-list))))
 		;; disposition-type
 		(choice :tag "Disposition-Type"
@@ -799,8 +717,7 @@ If encoding is nil, it is determined from its contents."
 			string)
 		;; parameters
 		(repeat :tag "Parameters of Content-Disposition field"
-			(cons string (choice string symbol)))
-		))
+			(cons string (choice string symbol)))))
   :group 'mime-edit)
 
 (defvar mime-edit-debug nil)
@@ -832,8 +749,7 @@ If encoding is nil, it is determined from its contents."
     (shift_jis		8 "base64")
     (tis-620		8 "base64")
     (iso-2022-jp-2	7 "base64")
-    (iso-2022-int-1	7 "base64")
-    ))
+    (iso-2022-int-1	7 "base64")))
 
 (defvar mime-transfer-level 7
   "*A number of network transfer level.  It should be 7 or bigger.")
@@ -842,8 +758,7 @@ If encoding is nil, it is determined from its contents."
 (defsubst mime-encoding-name (transfer-level &optional not-omit)
   (cond ((> transfer-level 8) "binary")
 	((= transfer-level 8) "8bit")
-	(not-omit "7bit")
-	))
+	(not-omit "7bit")))
 
 (defvar mime-transfer-level-string
   (mime-encoding-name mime-transfer-level 'not-omit)
@@ -1145,8 +1060,7 @@ Tspecials means any character that matches with it in header must be quoted.")
     (sign	"PGP sign"		mime-edit-set-sign)
     (encrypt	"PGP encrypt"		mime-edit-set-encrypt)
     (preview	"Preview Message"	mime-edit-preview-message)
-    (level	"Toggle transfer-level"	mime-edit-toggle-transfer-level)
-    )
+    (level	"Toggle transfer-level"	mime-edit-toggle-transfer-level))
   "MIME-edit menubar entry.")
 
 (define-key mime-edit-mode-map [menu-bar mime-edit]
@@ -1306,8 +1220,7 @@ User customizable variables (not documented all of them):
 	(mime-edit-again)
       (make-local-variable 'mime-edit-touched-flag)
       (setq mime-edit-touched-flag t)
-      (turn-on-mime-edit)
-      )))
+      (turn-on-mime-edit))))
 
 
 (set-alist 'minor-mode-alist
@@ -1344,8 +1257,7 @@ User customizable variables (not documented all of them):
     (message
      "%s"
      (substitute-command-keys
-      "Type \\[mime-edit-exit] to exit MIME mode, and type \\[mime-edit-help] to get help."))
-    ))
+      "Type \\[mime-edit-exit] to exit MIME mode, and type \\[mime-edit-help] to get help."))))
 
 ;;;###autoload
 (defalias 'edit-mime 'turn-on-mime-edit) ; for convenience
@@ -1358,8 +1270,7 @@ just return to previous mode."
   (interactive "P")
   (if (not mime-edit-mode-flag)
       (if (null no-error)
-	  (error "You aren't editing a MIME message.")
-	)
+	  (error "You aren't editing a MIME message."))
     (if (not nomime)
 	(progn
 	  (run-hooks 'mime-edit-translate-hook)
@@ -1368,14 +1279,12 @@ just return to previous mode."
     (setq mime-edit-mode-flag nil)
     (set-buffer-modified-p (buffer-modified-p))
     (run-hooks 'mime-edit-exit-hook)
-    (message "Exit MIME editor mode.")
-    ))
+    (message "Exit MIME editor mode.")))
 
 (defun mime-edit-maybe-translate ()
   (interactive)
   (mime-edit-exit nil t)
-  (call-interactively 'mime-edit-maybe-split-and-send)
-  )
+  (call-interactively 'mime-edit-maybe-split-and-send))
 
 (defun mime-edit-help ()
   "Show help message about MIME mode."
@@ -1396,15 +1305,12 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	  (progn
 	    ;; Make a space between the following message.
 	    (insert "\n")
-	    (forward-char -1)
-	    ))
+	    (forward-char -1)))
       (if (and (member (cadr ret) '("enriched"))
 	       (fboundp 'enriched-mode))
 	  (enriched-mode t)
 	(if (boundp 'enriched-mode)
-	    (enriched-mode -1)
-	  ))
-      )))
+	    (enriched-mode -1))))))
 
 (defun mime-edit-insert-file-filename (file)
   (std11-wrap-as-quoted-string
@@ -1416,8 +1322,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
      ;; If FLIM does not support non-ASCII
      ;; filename, it is encoded.
      (eword-encode-string
-      (file-name-nondirectory file))
-     )))
+      (file-name-nondirectory file)))))
 
 (defun mime-edit-insert-file-charset (file &optional verbose)
   (let ((charset (with-temp-buffer
@@ -1460,8 +1365,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	  (parameters (nth 2 guess))
 	  (encoding (nth 3 guess))
 	  (disposition-type (nth 4 guess))
-	  (disposition-params (nth 5 guess))
-	  )
+	  (disposition-params (nth 5 guess)))
     (setq verbose (or (called-interactively-p 'interactive) verbose))
     (if verbose
 	(setq type (mime-prompt-for-type type)
@@ -1476,8 +1380,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 		     (mime-edit-insert-file-parameters
 		      disposition-params file verbose)))))
     (mime-edit-insert-tag type subtype parameters)
-    (mime-edit-insert-binary-file file encoding)
-    ))
+    (mime-edit-insert-binary-file file encoding)))
 
 (defun mime-edit-insert-file-as-text (file &optional verbose)
   "Insert a text from a file.  This function decodes inserted file and does not define Content-Transfer-Encoding: header and charset parameter."
@@ -1487,8 +1390,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	  (subtype (if (equal (nth 0 guess) "text") (nth 1 guess) "plain"))
 	  (parameters (nth 2 guess))
 	  (disposition-type (nth 4 guess))
-	  (disposition-params (nth 5 guess))
-	  )
+	  (disposition-params (nth 5 guess)))
     (setq verbose (or (called-interactively-p 'interactive) verbose))
     (if verbose
 	(setq subtype (mime-prompt-for-subtype type subtype)))
@@ -1504,8 +1406,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	       (remove (assoc "charset" disposition-params) disposition-params)
 	       file verbose)))))
     (mime-edit-insert-tag type subtype parameters)
-    (mime-edit-insert-text-file file)
-    ))
+    (mime-edit-insert-text-file file)))
 
 (defun mime-edit-insert-external ()
   "Insert a reference to external body."
@@ -1538,8 +1439,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	(progn
 	  (insert "\n")
 	  (invisible-region (point-min)(point-max))
-	  (goto-char (point-max))
-	  )))))
+	  (goto-char (point-max)))))))
 
 (autoload 'mime-edit-insert-signature "mime-signature" nil t)
 
@@ -1554,15 +1454,12 @@ If nothing is inserted, return nil."
     (mime-edit-goto-tag)
     (if (and (re-search-forward mime-edit-tag-regexp nil t)
 	     (< (match-beginning 0) p)
-	     (< p (match-end 0))
-	     )
+	     (< p (match-end 0)))
 	(goto-char (match-beginning 0))
-      (goto-char p)
-      ))
+      (goto-char p)))
   (let ((oldtag nil)
 	(newtag nil)
-	(current (point))
-	)
+	(current (point)))
     (setq pritype
 	  (or pritype
 	      (mime-prompt-for-type)))
@@ -1580,8 +1477,7 @@ If nothing is inserted, return nil."
 	    (if (mime-edit-goto-tag)
 		(buffer-substring (match-beginning 0) (match-end 0))
 	      ;; Assume content type is 'text/plan'.
-	      (mime-make-tag "text" "plain")
-	      )))
+	      (mime-make-tag "text" "plain"))))
     ;; We are only interested in TEXT.
     (if (and oldtag
 	     (not (mime-test-content-type
@@ -1600,8 +1496,7 @@ If nothing is inserted, return nil."
       ;; Restore previous point.
       (goto-char current)
       nil				;Nothing is created.
-      )
-    ))
+      )))
 
 (defun mime-edit-insert-binary-file (file &optional encoding)
   "Insert binary FILE at point.
@@ -1613,31 +1508,24 @@ Optional argument ENCODING specifies an encoding method such as base64."
 		       (let ((en (downcase encoding)))
 			 (or (string-equal en "7bit")
 			     (string-equal en "8bit")
-			     (string-equal en "binary")
-			     )))))
-	 )
+			     (string-equal en "binary")))))))
     (save-restriction
       (narrow-to-region tagend (point))
       (mime-insert-encoded-file file encoding)
       (if hide-p
 	  (progn
 	    (invisible-region (point-min) (point-max))
-	    (goto-char (point-max))
-	    )
-	(goto-char (point-max))
-	))
+	    (goto-char (point-max)))
+	(goto-char (point-max))))
     (or hide-p
 	(looking-at mime-edit-tag-regexp)
 	(= (point)(point-max))
-	(mime-edit-insert-tag "text" "plain")
-	)
+	(mime-edit-insert-tag "text" "plain"))
     ;; Define encoding even if it is 7bit.
     (if (stringp encoding)
 	(save-excursion
 	  (goto-char tagend) ; Make sure which line the tag is on.
-	  (mime-edit-define-encoding encoding)
-	  ))
-    ))
+	  (mime-edit-define-encoding encoding)))))
 
 (defun mime-edit-insert-text-file (file &optional _encoding)
   "Insert text FILE at point.
@@ -1646,13 +1534,10 @@ Optional argument ENCODING is ignored."
     (save-restriction
       (narrow-to-region tagend (point))
       (insert-file-contents file)
-      (goto-char (point-max))
-      )
+      (goto-char (point-max)))
     (or (looking-at mime-edit-tag-regexp)
 	(= (point)(point-max))
-	(mime-edit-insert-tag "text" "plain")
-	)
-    ))
+	(mime-edit-insert-tag "text" "plain"))))
 
 
 ;; Commands work on a current message flagment.
@@ -1667,17 +1552,14 @@ Optional argument ENCODING is ignored."
 	     (goto-char (1- (match-beginning 0))) ;For multiline tag
 	     )
 	    (t
-	     (goto-char (point-max))
-	     ))
+	     (goto-char (point-max))))
       ;; Then search for the beginning.
       (re-search-backward mime-edit-end-tag-regexp nil t)
       (or (looking-at mime-edit-beginning-tag-regexp)
 	  ;; Restore previous point.
 	  (progn
 	    (goto-char current)
-	    nil
-	    ))
-      )))
+	    nil)))))
 
 (defun mime-edit-content-beginning ()
   "Return the point of the beginning of content."
@@ -1698,8 +1580,7 @@ Optional argument ENCODING is ignored."
 	 (concat "\n" (regexp-quote mail-header-separator)
 		 (if mime-ignore-preceding-spaces
 		     "[ \t\n]*\n" "\n")) nil 'move)
-	(point))
-      )))
+	(point)))))
 
 (defun mime-edit-content-end ()
   "Return the point of the end of content."
@@ -1712,17 +1593,14 @@ Optional argument ENCODING is ignored."
 	    ;; Move to the end of this text.
 	    (if (re-search-forward mime-edit-tag-regexp nil 'move)
 		;; Don't forget a multiline tag.
-		(goto-char (match-beginning 0))
-	      )
-	    (point)
-	    ))
+		(goto-char (match-beginning 0)))
+	    (point)))
       ;; Assume the message begins with text/plain.
       (goto-char (mime-edit-content-beginning))
       (if (re-search-forward mime-edit-tag-regexp nil 'move)
 	  ;; Don't forget a multiline tag.
 	  (goto-char (match-beginning 0)))
-      (point))
-    ))
+      (point))))
 
 (defun mime-edit-define-charset (charset)
   "Set charset of current tag to CHARSET."
@@ -1739,8 +1617,7 @@ Optional argument ENCODING is ignored."
 	       (if comment
 		   (concat (upcase (symbol-name charset)) " (" comment ")")
 		 (upcase (symbol-name charset)))))
-	    (mime-edit-get-encoding tag)))
-	  ))))
+	    (mime-edit-get-encoding tag)))))))
 
 (defun mime-edit-define-encoding (encoding)
   "Set encoding of current tag to ENCODING."
@@ -1748,13 +1625,11 @@ Optional argument ENCODING is ignored."
     (if (mime-edit-goto-tag)
 	(let ((tag (buffer-substring (match-beginning 0) (match-end 0))))
 	  (delete-region (match-beginning 0) (match-end 0))
-	  (insert (mime-create-tag (mime-edit-get-contype tag) encoding)))
-      )))
+	  (insert (mime-create-tag (mime-edit-get-contype tag) encoding))))))
 
 (defun mime-edit-choose-charset ()
   "Choose charset of a text following current point."
-  (detect-mime-charset-region (point) (mime-edit-content-end))
-  )
+  (detect-mime-charset-region (point) (mime-edit-content-end)))
 
 (defun mime-make-text-tag (&optional subtype)
   "Make a tag for a text after current point.
@@ -1784,10 +1659,8 @@ Otherwise, it is obtained from mime-content-types."
   (and (stringp tag)
        (or (string-match mime-edit-single-part-tag-regexp tag)
 	   (string-match mime-edit-multipart-beginning-regexp tag)
-	   (string-match mime-edit-multipart-end-regexp tag)
-	   )
-       (substring tag (match-beginning 1) (match-end 1))
-       ))
+	   (string-match mime-edit-multipart-end-regexp tag))
+       (substring tag (match-beginning 1) (match-end 1))))
 
 (defun mime-edit-get-encoding (tag)
   "Return encoding of TAG."
@@ -1816,8 +1689,7 @@ Nil if no such parameter."
     (if (string-match "\n[^ \t\n\r]+:" contype)
 	(setq ctype (substring contype 0 (match-beginning 0))
 	      opt-fields (substring contype (match-beginning 0)))
-      (setq ctype contype)
-      )
+      (setq ctype contype))
     (if (string-match
 	 (concat
 	  ";[ \t\n]*\\("
@@ -1856,8 +1728,7 @@ Nil if no such parameter."
       (if (string-match (car (car guesses)) file)
 	  (setq guess (cdr (car guesses))))
       (setq guesses (cdr guesses)))
-    guess
-    ))
+    guess))
 
 (defun mime-prompt-for-type (&optional default)
   "Ask for Content-type."
@@ -1905,8 +1776,7 @@ Optional DELIMITER specifies parameter delimiter (';' by default)."
 		 (mime-prompt-for-parameters-1
 		  (cdr (assoc subtype
 			      (cdr (assoc pritype mime-content-types))))))
-	   delimiter
-	   )))
+	   delimiter)))
     (if (and (stringp parameters)
 	     (not (string-equal parameters "")))
 	(concat delimiter parameters)
@@ -1940,8 +1810,7 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
 		      ;; Note: control characters ignored!
 		      (if (string-match mime-tspecials-regexp answer)
 			  (concat "\"" answer "\"") answer)))
-	  (mime-prompt-for-parameters-1 (cdr (assoc answer (cdr parameter)))))
-    ))
+	  (mime-prompt-for-parameters-1 (cdr (assoc answer (cdr parameter)))))))
 
 (defun mime-prompt-for-encoding (&optional default)
   "Ask for Content-Transfer-Encoding."
@@ -2006,26 +1875,22 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
 	(widen)
 	(if (re-search-forward end-exp nil t)
 	    (setq eb (match-beginning 0))
-	  (setq eb (point-max))
-	  )
+	  (setq eb (point-max)))
 	(narrow-to-region be eb)
 	(goto-char be)
 	(if (re-search-forward mime-edit-multipart-beginning-regexp nil t)
 	    (progn
 	      (narrow-to-region (match-beginning 0)(point-max))
-	      (mime-edit-find-inmost)
-	      )
+	      (mime-edit-find-inmost))
 	  (widen)
-	  (list type bb be eb)
-	  ))))
+	  (list type bb be eb)))))
 
 (defun mime-edit-process-multipart-1 (boundary)
   (let ((ret (mime-edit-find-inmost)))
     (if ret
 	(let ((type (car ret))
 	      (bb (nth 1 ret))(be (nth 2 ret))
-	      (eb (nth 3 ret))
-	      )
+	      (eb (nth 3 ret)))
 	  (narrow-to-region bb eb)
 	  (delete-region bb be)
 	  (setq bb (point-min))
@@ -2034,29 +1899,22 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
 	  (goto-char eb)
 	  (if (looking-at mime-edit-multipart-end-regexp)
 	      (let ((beg (match-beginning 0))
-		    (end (match-end 0))
-		    )
+		    (end (match-end 0)))
 		(delete-region beg end)
 		(or (looking-at mime-edit-beginning-tag-regexp)
 		    (looking-at mime-edit-multipart-end-regexp)
 		    (eobp)
-		    (insert (mime-make-text-tag) "\n")
-		    )))
+		    (insert (mime-make-text-tag) "\n"))))
 	  (cond ((string-equal type "quote")
-		 (mime-edit-enquote-region bb eb)
-		 )
+		 (mime-edit-enquote-region bb eb))
 		((string-equal type "pgp-signed")
-		 (mime-edit-sign-pgp-mime bb eb boundary)
-		 )
+		 (mime-edit-sign-pgp-mime bb eb boundary))
 		((string-equal type "pgp-encrypted")
-		 (mime-edit-encrypt-pgp-mime bb eb boundary)
-		 )
+		 (mime-edit-encrypt-pgp-mime bb eb boundary))
 		((string-equal type "smime-signed")
-		 (mime-edit-sign-smime bb eb boundary)
-		 )
+		 (mime-edit-sign-smime bb eb boundary))
 		((string-equal type "smime-encrypted")
-		 (mime-edit-encrypt-smime bb eb boundary)
-		 )
+		 (mime-edit-encrypt-smime bb eb boundary))
 		(t
 		 (setq boundary
 		       (nth 2 (mime-edit-translate-region bb eb
@@ -2065,8 +1923,7 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
 		 (insert
 		  (format "--[[multipart/%s;
  boundary=\"%s\"][7bit]]\n"
-			  type boundary))
-		 ))
+			  type boundary))))
 	  boundary))))
 
 (defun mime-edit-enquote-region (beg end)
@@ -2076,8 +1933,7 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
       (goto-char beg)
       (while (re-search-forward mime-edit-single-part-tag-regexp nil t)
 	(let ((tag (buffer-substring (match-beginning 0)(match-end 0))))
-	  (replace-match (concat "- " (substring tag 1)))
-	  )))))
+	  (replace-match (concat "- " (substring tag 1))))))))
 
 (defun mime-edit-dequote-region (beg end)
   (save-excursion
@@ -2087,8 +1943,7 @@ Parameter must be '(PROMPT CHOICE1 (CHOICE2...))."
       (while (re-search-forward
 	      mime-edit-quoted-single-part-tag-regexp nil t)
 	(let ((tag (buffer-substring (match-beginning 0)(match-end 0))))
-	  (replace-match (concat "-" (substring tag 2)))
-	  )))))
+	  (replace-match (concat "-" (substring tag 2))))))))
 
 (defun mime-edit-delete-trailing-whitespace ()
   (save-match-data
@@ -2153,8 +2008,7 @@ If no one is selected, default secret key is used.  "
 	       (if (r1 != ?\r)
 		   (write ?\r)))
 	   (r1 = r0)
-	   (write-repeat r0)))))
-)
+	   (write-repeat r0))))))
 
 (defun mime-edit-sign-pgp-mime (beg end boundary)
   (save-excursion
@@ -2171,8 +2025,7 @@ If no one is selected, default secret key is used.  "
 	(goto-char beg)
 	(insert (format "Content-Type: %s\n" ctype))
 	(if encoding
-	    (insert (format "Content-Transfer-Encoding: %s\n" encoding))
-	  )
+	    (insert (format "Content-Transfer-Encoding: %s\n" encoding)))
 	(insert "\n")
 	(epg-context-set-armor context t)
 	(epg-context-set-textmode context nil)
@@ -2223,8 +2076,7 @@ Content-Description: OpenPGP Digital Signature
 " pgp-boundary))
 	(insert signature)
 	(goto-char (point-max))
-	(insert (format "\n--%s--\n" pgp-boundary))
-	))))
+	(insert (format "\n--%s--\n" pgp-boundary))))))
 
 (defun mime-edit-text-coding ()
   (save-excursion
@@ -2317,8 +2169,7 @@ If no one is selected, symmetric encryption will be performed.  ")
 			   (or (epg-expand-group config recipient)
 			       (list (concat "<" recipient ">"))))
 			 (apply #'nconc recipients)))
-	  (apply #'concat (nreverse header)))
-    ))
+	  (apply #'concat (nreverse header)))))
 
 (defcustom mime-edit-encrypt-pgp-ignore-missing-keys 'ask
   "Define the behavior when no available key for recipient was found.
@@ -2370,8 +2221,7 @@ When value is other non-nil, show only message and proceed."
           (insert header)
           (insert (format "Content-Type: %s\n" ctype))
           (if encoding
-              (insert (format "Content-Transfer-Encoding: %s\n" encoding))
-	    )
+              (insert (format "Content-Transfer-Encoding: %s\n" encoding)))
           (insert "\n")
 	  (mime-encode-header-in-buffer)
 	  (epg-context-set-armor context t)
@@ -2404,8 +2254,7 @@ Content-Transfer-Encoding: 7bit
 " pgp-boundary pgp-boundary pgp-boundary))
 	  (insert cipher)
 	  (goto-char (point-max))
-	  (insert (format "\n--%s--\n" pgp-boundary))
-	  )))))
+	  (insert (format "\n--%s--\n" pgp-boundary)))))))
 
 (defun mime-edit-convert-lbt-string (string)
   (let (inhibit-eol-conversion)
@@ -2426,8 +2275,7 @@ Content-Transfer-Encoding: 7bit
 	(goto-char beg)
 	(insert (format "Content-Type: %s\n" ctype))
 	(if encoding
-	    (insert (format "Content-Transfer-Encoding: %s\n" encoding))
-	  )
+	    (insert (format "Content-Transfer-Encoding: %s\n" encoding)))
 	(insert "\n")
 	(epg-context-set-signers
 	 context
@@ -2515,13 +2363,11 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	       (list
 		(if (eq arg ?\ )
 		    ?_
-		  arg))) str nil)
-  )
+		  arg))) str nil))
 
 (defun mime-edit-make-boundary ()
   (concat mime-multipart-boundary "_"
-	  (replace-space-with-underline (current-time-string))
-	  ))
+	  (replace-space-with-underline (current-time-string))))
 
 (defun mime-edit-translate-body ()
   "Encode the tagged MIME body in current buffer in MIME compliant message."
@@ -2532,8 +2378,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	  ret)
       (while (mime-edit-process-multipart-1
 	      (format "%s-%d" boundary i))
-	(setq i (1+ i))
-	)
+	(setq i (1+ i)))
       (save-restriction
 	;; We are interested in message body.
 	(let* ((beg
@@ -2553,8 +2398,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 		  (point))))
 	  (setq ret (mime-edit-translate-region
 		     beg end
-		     (format "%s-%d" boundary i)))
-	  ))
+		     (format "%s-%d" boundary i)))))
       (mime-edit-dequote-region (point-min)(point-max))
       (let ((contype (car ret))		;Content-Type
 	    (encoding (nth 1 ret))	;Content-Transfer-Encoding
@@ -2562,8 +2406,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	;; Insert User-Agent field
 	(and mime-edit-insert-user-agent-field
 	     (or (mail-position-on-field "User-Agent")
-		 (insert mime-edit-user-agent-value)
-		 ))
+		 (insert mime-edit-user-agent-value)))
 	;; Make primary MIME headers.
 	(or (mail-position-on-field "MIME-Version")
 	    (insert mime-edit-mime-version-value))
@@ -2581,8 +2424,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	(if encoding
 	    (progn
 	      (mail-position-on-field "Content-Transfer-Encoding")
-	      (insert encoding)))
-	))))
+	      (insert encoding)))))))
 
 (defun mime-edit-translate-single-part-tag (boundary &optional prefix)
   "Translate single-part-tag to MIME header."
@@ -2603,13 +2445,11 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	  (cons (and contype
 		     (downcase contype))
 		(and encoding
-		     (downcase encoding))))
-	)))
+		     (downcase encoding)))))))
 
 (defun mime-edit-translate-region (beg end &optional boundary multipart)
   (or boundary
-      (setq boundary (mime-edit-make-boundary))
-      )
+      (setq boundary (mime-edit-make-boundary)))
   (save-excursion
     (save-restriction
       (narrow-to-region beg end)
@@ -2635,8 +2475,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 		  (buffer-substring (match-beginning 0) (match-end 0)))
 	    (delete-region (match-beginning 0) (1+ (match-end 0)))
 	    (setq contype (mime-edit-get-contype tag))
-	    (setq encoding (mime-edit-get-encoding tag))
-	    ))
+	    (setq encoding (mime-edit-get-encoding tag))))
 	 (t
 	  ;; It's a multipart message.
 	  (goto-char (point-min))
@@ -2656,10 +2495,8 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	    (setq encoding (car prio))
 	    ;; Insert the trailer.
 	    (goto-char (point-max))
-	    (insert "\n--" boundary "--\n")
-	    )))
-	 (list contype encoding boundary nparts)
-	 ))))
+	    (insert "\n--" boundary "--\n"))))
+	 (list contype encoding boundary nparts)))))
 
 (defun mime-edit-normalize-body ()
   "Normalize the body part by inserting appropriate message tags."
@@ -2678,23 +2515,19 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
       (if (looking-at "[ \t]+$")
 	  (delete-region (match-beginning 0) (match-end 0)))
       (let ((beg (point))
-	    (end (mime-edit-content-end))
-	    )
+	    (end (mime-edit-content-end)))
 	(if (= end (point-max))
 	    nil
 	  (goto-char end)
 	  (or (looking-at mime-edit-beginning-tag-regexp)
 	      (eobp)
-	      (insert (mime-make-text-tag) "\n")
-	      ))
+	      (insert (mime-make-text-tag) "\n")))
 	(visible-region beg end)
-	(goto-char beg)
-	)
+	(goto-char beg))
       (cond
        ((mime-test-content-type contype "message")
 	;; Content-type "message" should be sent as is.
-	(forward-line 1)
-	)
+	(forward-line 1))
        ((mime-test-content-type contype "text")
 	;; Define charset for text.
 	(setq charset
@@ -2723,15 +2556,13 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	(cond ((string-equal contype "text/x-rot13-47-48")
 	       (save-excursion
 		 (forward-line)
-		 (mule-caesar-region (point) (mime-edit-content-end))
-		 ))
+		 (mule-caesar-region (point) (mime-edit-content-end))))
 	      ((string-equal contype "text/enriched")
 	       (save-excursion
 		 (let ((beg (progn
 			      (forward-line)
 			      (point)))
-		       (end (mime-edit-content-end))
-		       )
+		       (end (mime-edit-content-end)))
 		   ;; Patch for hard newlines
                    ;; (save-excursion
                    ;;   (goto-char beg)
@@ -2743,9 +2574,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 		   (enriched-encode beg end nil)
 		   (goto-char beg)
 		   (if (search-forward "\n\n")
-		       (delete-region beg (match-end 0))
-		     )
-		   ))))
+		       (delete-region beg (match-end 0)))))))
 	;; Point is now on current tag.
 	;; Define encoding and encode text if necessary.
 	(or encoding	;Encoding is not specified.
@@ -2776,10 +2605,8 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 					    x-ctext))
 			    (while (progn
 				     (replace-match "\e(BFrom ")
-				     (re-search-forward "^From " nil t)
-				     ))
-			  (setq encoding "quoted-printable")
-			  )))))
+				     (re-search-forward "^From " nil t)))
+			  (setq encoding "quoted-printable"))))))
 	      ;; canonicalize line break code
 	      (or (member encoding '(nil "7bit" "8bit" "quoted-printable"))
 		  (save-restriction
@@ -2796,10 +2623,8 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	      (goto-char beg)
 	      (mime-encode-region beg (mime-edit-content-end)
 				  (or encoding "7bit"))
-	      (mime-edit-define-encoding encoding)
-	      ))
-	(goto-char (mime-edit-content-end))
-	)
+	      (mime-edit-define-encoding encoding)))
+	(goto-char (mime-edit-content-end)))
        ((null encoding)		;Encoding is not specified.
 	;; Application, image, audio, video, and any other
 	;; unknown content-type without encoding should be
@@ -2809,9 +2634,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 	       (end (mime-edit-content-end)))
 	  (mime-encode-region beg end encoding)
 	  (mime-edit-define-encoding encoding))
-	(forward-line 1)
-	))
-      )))
+	(forward-line 1))))))
 
 (defun mime-delete-field (field)
   "Delete header FIELD."
@@ -2833,8 +2656,7 @@ Content-Disposition: attachment; filename=smime.p7m][base64]]
 and insert data encoded as ENCODING."
   (message "Start the recording on %s.  Type C-g to finish the recording..."
 	   (system-name))
-  (mime-insert-encoded-file "/dev/audio" encoding)
-  )
+  (mime-insert-encoded-file "/dev/audio" encoding))
 
 
 ;;; @ Other useful commands.
@@ -2848,10 +2670,8 @@ and insert data encoded as ENCODING."
     (if (and inserter (fboundp inserter))
 	(progn
 	  (mime-edit-insert-tag "message" "rfc822")
-	  (funcall inserter message)
-	  )
-      (message "Sorry, I don't have message inserter for your MUA.")
-      )))
+	  (funcall inserter message))
+      (message "Sorry, I don't have message inserter for your MUA."))))
 
 (defun mime-edit-insert-mail (&optional message)
   (interactive)
@@ -2859,10 +2679,8 @@ and insert data encoded as ENCODING."
     (if (and inserter (fboundp inserter))
 	(progn
 	  (mime-edit-insert-tag "message" "rfc822")
-	  (funcall inserter message)
-	  )
-      (message "Sorry, I don't have mail inserter for your MUA.")
-      )))
+	  (funcall inserter message))
+      (message "Sorry, I don't have mail inserter for your MUA."))))
 
 (defun mime-edit-inserted-message-filter ()
   (save-excursion
@@ -2873,17 +2691,13 @@ and insert data encoded as ENCODING."
 	;; for Emacs 18
 	;; (if (re-search-forward "^$" (marker-position (mark-marker)))
 	(if (re-search-forward "^$" (mark t))
-	    (narrow-to-region header-start (match-beginning 0))
-	  )
+	    (narrow-to-region header-start (match-beginning 0)))
 	(goto-char header-start)
 	(while (and (re-search-forward
 		     mime-edit-yank-ignored-field-regexp nil t)
 		    (setq beg (match-beginning 0))
-		    (setq end (1+ (std11-field-end)))
-		    )
-	  (delete-region beg end)
-	  )
-	))))
+		    (setq end (1+ (std11-field-end))))
+	  (delete-region beg end))))))
 
 
 ;;; @ multipart enclosure
@@ -2897,58 +2711,46 @@ and insert data encoded as ENCODING."
       (insert (format "--<<%s>>-{\n" type))
       (goto-char (point-max))
       (insert (format "--}-<<%s>>\n" type))
-      (goto-char (point-max))
-      )
+      (goto-char (point-max)))
     (or (looking-at mime-edit-beginning-tag-regexp)
 	(eobp)
-	(insert (mime-make-text-tag) "\n")
-	)
-    ))
+	(insert (mime-make-text-tag) "\n"))))
 
 (defun mime-edit-enclose-quote-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'quote beg end)
-  )
+  (mime-edit-enclose-region-internal 'quote beg end))
 
 (defun mime-edit-enclose-mixed-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'mixed beg end)
-  )
+  (mime-edit-enclose-region-internal 'mixed beg end))
 
 (defun mime-edit-enclose-parallel-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'parallel beg end)
-  )
+  (mime-edit-enclose-region-internal 'parallel beg end))
 
 (defun mime-edit-enclose-digest-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'digest beg end)
-  )
+  (mime-edit-enclose-region-internal 'digest beg end))
 
 (defun mime-edit-enclose-alternative-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'alternative beg end)
-  )
+  (mime-edit-enclose-region-internal 'alternative beg end))
 
 (defun mime-edit-enclose-pgp-signed-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'pgp-signed beg end)
-  )
+  (mime-edit-enclose-region-internal 'pgp-signed beg end))
 
 (defun mime-edit-enclose-pgp-encrypted-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'pgp-encrypted beg end)
-  )
+  (mime-edit-enclose-region-internal 'pgp-encrypted beg end))
 
 (defun mime-edit-enclose-smime-signed-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'smime-signed beg end)
-  )
+  (mime-edit-enclose-region-internal 'smime-signed beg end))
 
 (defun mime-edit-enclose-smime-encrypted-region (beg end)
   (interactive "*r")
-  (mime-edit-enclose-region-internal 'smime-encrypted beg end)
-  )
+  (mime-edit-enclose-region-internal 'smime-encrypted beg end))
 
 (defun mime-edit-insert-key (&optional _arg)
   "Insert a pgp public key."
@@ -2970,13 +2772,11 @@ and insert data encoded as ENCODING."
 (defun mime-edit-set-split (arg)
   (interactive
    (list
-    (y-or-n-p "Do you want to enable split? ")
-    ))
+    (y-or-n-p "Do you want to enable split? ")))
   (setq mime-edit-split-message arg)
   (if arg
       (message "This message is enabled to split.")
-    (message "This message is not enabled to split.")
-    ))
+    (message "This message is not enabled to split.")))
 
 (defun mime-edit-toggle-transfer-level (&optional transfer-level)
   "Toggle transfer-level is 7bit or 8bit through.
@@ -2987,24 +2787,20 @@ Optional TRANSFER-LEVEL is a number of transfer-level, 7 or 8."
       (setq mime-transfer-level transfer-level)
     (if (< mime-transfer-level 8)
 	(setq mime-transfer-level 8)
-      (setq mime-transfer-level 7)
-      ))
+      (setq mime-transfer-level 7)))
   (message (format "Current transfer-level is %d bit"
 		   mime-transfer-level))
   (setq mime-transfer-level-string
 	(mime-encoding-name mime-transfer-level 'not-omit))
-  (force-mode-line-update)
-  )
+  (force-mode-line-update))
 
 (defun mime-edit-set-transfer-level-7bit ()
   (interactive)
-  (mime-edit-toggle-transfer-level 7)
-  )
+  (mime-edit-toggle-transfer-level 7))
 
 (defun mime-edit-set-transfer-level-8bit ()
   (interactive)
-  (mime-edit-toggle-transfer-level 8)
-  )
+  (mime-edit-toggle-transfer-level 8))
 
 
 ;;; @ pgp
@@ -3016,52 +2812,43 @@ Optional TRANSFER-LEVEL is a number of transfer-level, 7 or 8."
 (defun mime-edit-set-sign (arg)
   (interactive
    (list
-    (y-or-n-p "Do you want to sign? ")
-    ))
+    (y-or-n-p "Do you want to sign? ")))
   (if arg
       (progn
 	(or (memq 'sign mime-edit-pgp-processing)
 	    (setq mime-edit-pgp-processing 
 		  (nconc mime-edit-pgp-processing 
 			 (copy-sequence '(sign)))))
-	(message "This message will be signed.")
-	)
+	(message "This message will be signed."))
     (setq mime-edit-pgp-processing 
 	  (delq 'sign mime-edit-pgp-processing))
-    (message "This message will not be signed.")
-    ))
+    (message "This message will not be signed.")))
 
 (defun mime-edit-set-encrypt (arg)
   (interactive
    (list
-    (y-or-n-p "Do you want to encrypt? ")
-    ))
+    (y-or-n-p "Do you want to encrypt? ")))
   (if arg
       (progn
 	(or (memq 'encrypt mime-edit-pgp-processing)
 	    (setq mime-edit-pgp-processing 
 		  (nconc mime-edit-pgp-processing 
 			 (copy-sequence '(encrypt)))))
-	(message "This message will be encrypted.")
-	)
+	(message "This message will be encrypted."))
     (setq mime-edit-pgp-processing
 	  (delq 'encrypt mime-edit-pgp-processing))
-    (message "This message will not be encrypted.")
-    ))
+    (message "This message will not be encrypted.")))
 
 (defun mime-edit-pgp-enclose-buffer ()
   (let ((beg (save-excursion
 	       (goto-char (point-min))
 	       (if (search-forward (concat "\n" mail-header-separator "\n"))
-		   (match-end 0)
-		 )))
-	)
+		   (match-end 0)))))
     (when beg
       (if (memq 'sign mime-edit-pgp-processing)
 	  (mime-edit-enclose-pgp-signed-region beg (point-max)))
       (if (memq 'encrypt mime-edit-pgp-processing)
-	  (mime-edit-enclose-pgp-encrypted-region beg (point-max)))
-      )))
+	  (mime-edit-enclose-pgp-encrypted-region beg (point-max))))))
 
 ;;; @ split
 ;;;
@@ -3073,21 +2860,18 @@ Optional TRANSFER-LEVEL is a number of transfer-level, 7 or 8."
   (insert mime-edit-mime-version-field-for-message/partial)
   (insert (format "\
 Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
-		  id number total separator))
-  )
+		  id number total separator)))
 
 (defun mime-edit-split-and-send
   (&optional cmd lines mime-edit-message-max-length)
   (interactive)
   (or lines
       (setq lines
-	    (count-lines (point-min) (point-max)))
-      )
+	    (count-lines (point-min) (point-max))))
   (or mime-edit-message-max-length
       (setq mime-edit-message-max-length
 	    (or (cdr (assq major-mode mime-edit-message-max-lines-alist))
-		mime-edit-message-default-max-lines))
-      )
+		mime-edit-message-default-max-lines)))
   (let ((separator mail-header-separator)
 	(id (concat "\""
 		    (replace-space-with-underline (current-time-string))
@@ -3108,9 +2892,7 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 		      mime-edit-split-message-sender-alist))
 	       (lambda ()
 		 (interactive)
-		 (error "Split sender is not specified for `%s'." major-mode)
-		 )
-	       ))
+		 (error "Split sender is not specified for `%s'." major-mode))))
 	  (mime-edit-partial-number 1)
 	  data)
       (with-current-buffer copy-buf
@@ -3122,13 +2904,11 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	       (concat "^" (regexp-quote separator) "$") nil t)
 	      (let ((he (match-beginning 0)))
 		(replace-match "")
-		(narrow-to-region (point-min) he)
-		))
+		(narrow-to-region (point-min) he)))
 	  (goto-char (point-min))
 	  (while (re-search-forward mime-edit-split-blind-field-regexp nil t)
 	    (delete-region (match-beginning 0)
-			   (1+ (std11-field-end)))
-	    )))
+			   (1+ (std11-field-end))))))
       (while (< mime-edit-partial-number total)
 	(erase-buffer)
 	(with-current-buffer copy-buf
@@ -3137,10 +2917,8 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 		      (progn
 			(goto-char (point-min))
 			(forward-line (1- mime-edit-message-max-length))
-			(point))
-		      ))
-	  (delete-region (point-min)(point))
-	  )
+			(point))))
+	  (delete-region (point-min)(point)))
 	(mime-edit-insert-partial-header
 	 header subject id mime-edit-partial-number total separator)
 	(insert data)
@@ -3149,16 +2927,13 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 			   mime-edit-partial-number total))
 	  (call-interactively command)
 	  (message (format "Sending %d/%d...done"
-			   mime-edit-partial-number total))
-	  )
+			   mime-edit-partial-number total)))
 	(setq mime-edit-partial-number
-	      (1+ mime-edit-partial-number))
-	)
+	      (1+ mime-edit-partial-number)))
       (erase-buffer)
       (with-current-buffer copy-buf
 	(setq data (buffer-string))
-	(erase-buffer)
-	)
+	(erase-buffer))
       (mime-edit-insert-partial-header
        header subject id mime-edit-partial-number total separator)
       (insert data)
@@ -3166,9 +2941,7 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	(message (format "Sending %d/%d..."
 			 mime-edit-partial-number total))
 	(message (format "Sending %d/%d...done"
-			 mime-edit-partial-number total))
-	)
-      )))
+			 mime-edit-partial-number total))))))
 
 (defun mime-edit-maybe-split-and-send (&optional cmd)
   (interactive)
@@ -3176,12 +2949,10 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
   (let ((mime-edit-message-max-length
 	 (or (cdr (assq major-mode mime-edit-message-max-lines-alist))
 	     mime-edit-message-default-max-lines))
-	(lines (count-lines (point-min) (point-max)))
-	)
+	(lines (count-lines (point-min) (point-max))))
     (if (and (> lines mime-edit-message-max-length)
 	     mime-edit-split-message)
-	(mime-edit-split-and-send cmd lines mime-edit-message-max-length)
-      )))
+	(mime-edit-split-and-send cmd lines mime-edit-message-max-length))))
 
 
 ;;; @ preview message
@@ -3199,16 +2970,13 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	 (buf-name (buffer-name))
 	 (temp-buf-name (concat "*temp-article:" buf-name "*"))
 	 (buf (get-buffer temp-buf-name))
-	 (pgp-processing mime-edit-pgp-processing)
-	 )
+	 (pgp-processing mime-edit-pgp-processing))
     (if buf
 	(progn
 	  (switch-to-buffer buf)
-	  (erase-buffer)
-	  )
+	  (erase-buffer))
       (setq buf (get-buffer-create temp-buf-name))
-      (switch-to-buffer buf)
-      )
+      (switch-to-buffer buf))
     (insert str)
     (setq major-mode 'mime-temp-message-mode)
     (make-local-variable 'mail-header-separator)
@@ -3228,8 +2996,7 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
     (goto-char (point-min))
     (if (re-search-forward
 	 (concat "^" (regexp-quote separator) "$"))
-	(replace-match "")
-      )
+	(replace-match ""))
     (mime-view-buffer)
     (make-local-variable 'mime-edit-temp-message-buffer)
     (setq mime-edit-temp-message-buffer buf)))
@@ -3294,8 +3061,7 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	    (save-excursion
 	      (if (re-search-forward boundary-pat nil t)
 		  (setq end (match-beginning 0))
-		(setq end (point-max))
-		)
+		(setq end (point-max)))
 	      (save-restriction
 		(narrow-to-region beg end)
 		(cond
@@ -3315,27 +3081,20 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 				   (if (search-forward "\n\n" nil t)
 				       (match-end 0)
 				     (point-min)))
-		    (goto-char (point-max))
-		    ))
+		    (goto-char (point-max))))
 		 (t 
 		  (mime-edit-decode-message-in-buffer
 		   (if (eq subtype 'digest)
 		       (eval-when-compile
-			 (make-mime-content-type 'message 'rfc822))
-		     )
+			 (make-mime-content-type 'message 'rfc822)))
 		   not-decode-text)
-		  (goto-char (point-max))
-		  ))
-		))))
-	))
+		  (goto-char (point-max))))))))))
     (goto-char (point-min))
     (or (= (point-min) 1)
 	(delete-region (point-min)
 		       (if (search-forward "\n\n" nil t)
 			   (match-end 0)
-			 (point-min)
-			 )))
-    ))
+			 (point-min))))))
 
 (defun mime-edit-decode-single-part-in-buffer
   (content-type not-decode-text &optional content-disposition)
@@ -3368,8 +3127,7 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 		       (concat "; " str)
 		     (setq bytes (+ bs 1))
 		     (concat ";\n " str)
-		     )
-		   )))
+		     ))))
 	     (mime-content-type-parameters content-type) nil)))
 	 encoding
 	 encoded
@@ -3397,16 +3155,13 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 				   (concat "; " str)
 				 (setq bytes (+ bs 1))
 				 (concat ";\n " str)
-				 )
-			       ))
+				 )))
 			   (mime-content-disposition-parameters
 			    content-disposition)
-			   nil))))
-	 )
+			   nil)))))
     (if disposition-type
 	(setq pstr (format "%s\nContent-Disposition: %s%s"
-			   pstr disposition-type disposition-str))
-      )
+			   pstr disposition-type disposition-str)))
     (mapc (lambda (field)
 	    (save-excursion
 	      (when (re-search-forward (concat "^" field ":") limit t)
@@ -3437,40 +3192,32 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 			(mime-decode-region
 			 (match-end 0)(point-max) encoding)
 			(setq encoded t
-			      encoding nil)
-			)))))))
+			      encoding nil))))))))
     (if (and (eq type 'text)
 	     (or encoded (not not-decode-text)))
  	(progn
  	  (save-excursion
  	    (goto-char (point-min))
  	    (while (re-search-forward "\r\n" nil t)
- 	      (replace-match "\n")
- 	      ))
+ 	      (replace-match "\n")))
  	  (decode-mime-charset-region (point-min)(point-max)
- 				      (or charset default-mime-charset))
-	  ))
+ 				      (or charset default-mime-charset))))
     (let ((he (if (re-search-forward "^$" nil t)
 		  (match-end 0)
-		(point-min)
-		)))
+		(point-min))))
       (if (and (eq type 'text)
 	       (eq subtype 'x-rot13-47-48))
-	  (mule-caesar-region he (point-max))
-	)
+	  (mule-caesar-region he (point-max)))
       (if (= (point-min) 1)
 	  (progn
 	    (goto-char he)
 	    (insert "\n"
 		    (mime-create-tag
-		     (format "%s/%s%s" type subtype pstr) encoding))
-	    )
+		     (format "%s/%s%s" type subtype pstr) encoding)))
 	(delete-region (point-min) he)
 	(insert
 	 (mime-create-tag (format "%s/%s%s" type subtype pstr)
-			  encoding))
-	))
-    ))
+			  encoding))))))
 
 ;;;###autoload
 (defun mime-edit-decode-message-in-buffer (&optional default-content-type
@@ -3484,19 +3231,15 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	    (cond
 	     ((and (eq type 'application)
 		   (eq (mime-content-type-subtype ctl) 'pgp-signature))
-	      (delete-region (point-min)(point-max))
-	      )
+	      (delete-region (point-min)(point-max)))
 	     ((eq type 'multipart)
-	      (mime-edit-decode-multipart-in-buffer ctl not-decode-text)
-	      )
+	      (mime-edit-decode-multipart-in-buffer ctl not-decode-text))
 	     (t
 	      (mime-edit-decode-single-part-in-buffer
-	       ctl not-decode-text (mime-read-Content-Disposition))
-	      )))
+	       ctl not-decode-text (mime-read-Content-Disposition)))))
 	(or not-decode-text
 	    (decode-mime-charset-region (point-min) (point-max)
-					default-mime-charset))
-	)
+					default-mime-charset)))
       (if (= (point-min) 1)
 	  (progn
 	    (save-restriction
@@ -3504,11 +3247,8 @@ Content-Type: message/partial; id=%s; number=%d; total=%d\n%s\n"
 	      (goto-char (point-min))
 	      (while (re-search-forward
 		      mime-edit-again-ignored-field-regexp nil t)
-		(delete-region (match-beginning 0) (1+ (std11-field-end)))
-		))
-	    (mime-decode-header-in-buffer (not not-decode-text))
-	    ))
-      )))
+		(delete-region (match-beginning 0) (1+ (std11-field-end)))))
+	    (mime-decode-header-in-buffer (not not-decode-text)))))))
 
 ;;;###autoload
 (defun mime-edit-again (&optional not-decode-text no-separator not-turn-on)
@@ -3520,17 +3260,14 @@ converted to MIME-Edit tags."
   (if (search-forward
        (concat "\n" (regexp-quote mail-header-separator) "\n")
        nil t)
-      (replace-match "\n\n")
-    )
+      (replace-match "\n\n"))
   (mime-edit-decode-message-in-buffer nil not-decode-text)
   (goto-char (point-min))
   (or no-separator
       (and (re-search-forward "^$")
-	   (replace-match mail-header-separator)
-	   ))
+	   (replace-match mail-header-separator)))
   (or not-turn-on
-      (turn-on-mime-edit)
-      ))
+      (turn-on-mime-edit)))
 
 
 ;;; @ end

--- a/mime-partial.el
+++ b/mime-partial.el
@@ -47,18 +47,15 @@ automatically."
     (setq full-file (concat root-dir "/FULL"))
     
     (if (null target)
-	(error "%s is not supported. Sorry." target)
-      )
+	(error "%s is not supported. Sorry." target))
     
     ;; if you can't parse the subject line, try simple decoding method
     (if (or (file-exists-p full-file)
-	    (not (y-or-n-p "Merge partials?"))
-	    )
+	    (not (y-or-n-p "Merge partials?")))
 	(mime-store-message/partial-piece entity situation)
       (setq subject-id (mime-entity-read-field entity 'Subject))
       (if (string-match "[0-9\n]+" subject-id)
-	  (setq subject-id (substring subject-id 0 (match-beginning 0)))
-	)
+	  (setq subject-id (substring subject-id 0 (match-beginning 0))))
       ;; Do not use `with-current-buffer'.  Inner save-excursion(),
       ;; the current buffer may be accessed.
       (save-excursion
@@ -69,25 +66,18 @@ automatically."
 	    (let* ((message
 		    ;; request message at the cursor in Subject buffer.
 		    (save-window-excursion
-		      (funcall request-partial-message-method)
-		      ))
+		      (funcall request-partial-message-method)))
 		   (situation (mime-entity-situation message))
 		   (the-id (cdr (assoc "id" situation))))
 	      (when (string= the-id id)
 		(with-current-buffer mother
-		  (mime-store-message/partial-piece message situation)
-		  )
+		  (mime-store-message/partial-piece message situation))
 		(if (file-exists-p full-file)
-		    (throw 'tag nil)
-		  ))
+		    (throw 'tag nil)))
 	      (if (not (progn
 			 (end-of-line)
-			 (search-forward subject-id nil t)
-			 ))
-		  (error "not found")
-		)
-	      ))
-	  )))))
+			 (search-forward subject-id nil t)))
+		  (error "not found")))))))))
 
 
 ;;; @ end

--- a/mime-play.el
+++ b/mime-play.el
@@ -81,8 +81,7 @@ If MODE is specified, play as it.  Default MODE is \"play\"."
 	      (setq situation
 		    (cons (cons 'ignore-examples ignore-examples)
 			  situation)))
-	  (mime-play-entity entity situation)
-	  ))))
+	  (mime-play-entity entity situation)))))
 
 ;;;###autoload
 (defun mime-play-entity (entity &optional situation ignored-method)
@@ -109,19 +108,15 @@ specified, play as it.  Default MODE is \"play\"."
 				 situation))
 			      ret)))
 	   (setq ret (mime-sort-situation ret))
-	   (add-to-list 'mime-acting-situation-example-list (cons ret 0))
-	   )
+	   (add-to-list 'mime-acting-situation-example-list (cons ret 0)))
 	  (t
-	   (setq ret (car ret))
-	   ))
+	   (setq ret (car ret))))
     (setq method (cdr (assq 'method ret)))
     (cond ((and (symbolp method)
 		(fboundp method))
-	   (funcall method entity ret)
-	   )
+	   (funcall method entity ret))
 	  ((stringp method)
-	   (mime-activate-mailcap-method entity ret)
-	   )
+	   (mime-activate-mailcap-method entity ret))
           ;; ((and (listp method)(stringp (car method)))
           ;;  (mime-activate-external-method entity ret)
           ;;  )
@@ -131,9 +126,7 @@ specified, play as it.  Default MODE is \"play\"."
 				   (cdr (assq 'type situation))
 				   (cdr (assq 'subtype situation))))
 	   (if (y-or-n-p "Do you want to save current entity to disk?")
-	       (mime-save-content entity situation))
-	   ))
-    ))
+	       (mime-save-content entity situation))))))
 
 
 ;;; @ external decoder
@@ -209,19 +202,14 @@ window.")
 		   (- (window-height)
 		      (if (functionp mime-echo-window-height)
 			  (funcall mime-echo-window-height)
-			mime-echo-window-height)
-		      )))
-	)
-      (set-window-buffer win mime-echo-buffer-name)
-      )
+			mime-echo-window-height)))))
+      (set-window-buffer win mime-echo-buffer-name))
     (select-window win)
     (goto-char (point-max))
     (if forms
 	(let ((buffer-read-only nil))
-	  (insert (apply (function format) forms))
-	  ))
-    (select-window the-win)
-    ))
+	  (insert (apply (function format) forms))))
+    (select-window the-win)))
 
 
 ;;; @ file name
@@ -246,11 +234,9 @@ window.")
 	       (if (and subj
 			(or (string-match mime-view-file-name-regexp-1 subj)
 			    (string-match mime-view-file-name-regexp-2 subj)))
-		   (substring subj (match-beginning 0)(match-end 0))
-		 )))))
+		   (substring subj (match-beginning 0)(match-end 0)))))))
     (if filename
-	(replace-as-filename filename)
-      )))
+	(replace-as-filename filename))))
 
 
 ;;; @ file extraction
@@ -289,8 +275,7 @@ window.")
     ("^II\\*\000"			image tiff)
     ("^MM\000\\*"			image tiff)
     ("^MThd"				audio midi)
-    ("^\000\000\001\263"		video mpeg)
-    )
+    ("^\000\000\001\263"		video mpeg))
   "*Alist of regexp about magic-number vs. corresponding media-types.
 Each element looks like (REGEXP TYPE SUBTYPE).
 REGEXP is a regular expression to match against the beginning of the
@@ -306,8 +291,7 @@ SUBTYPE is symbol to indicate subtype of media-type.")
 		    (if cell
 			(if (string-match (car cell) mdata)
 			    (setq type (nth 1 cell)
-				  subtype (nth 2 cell))
-			  )
+				  subtype (nth 2 cell)))
 		      t)))
 	(setq rest (cdr rest))))
     (setq situation (del-alist 'method (copy-alist situation)))
@@ -348,8 +332,7 @@ It is registered to variable `mime-preview-quitting-method-alist'."
 	(let ((m-win (get-buffer-window mother)))
 	  (if m-win
 	      (set-window-buffer m-win preview-buffer)
-	    (switch-to-buffer preview-buffer)
-	    )))))
+	    (switch-to-buffer preview-buffer))))))
 
 
 ;;; @ message/partial
@@ -431,21 +414,16 @@ occurs."
 			  (erase-buffer)
 			  (insert total)
 			  (write-region (point-min)(point-max) total-file)
-			  (kill-buffer (current-buffer))
-			  ))
-		    (string-to-number total)
-		    )
+			  (kill-buffer (current-buffer))))
+		    (string-to-number total))
 		(and (file-exists-p total-file)
 		     (with-current-buffer (find-file-noselect total-file)
 		       (prog1
 			   (and (re-search-forward "[0-9]+" nil t)
 				(string-to-number
 				 (buffer-substring (match-beginning 0)
-						   (match-end 0)))
-				)
-			 (kill-buffer (current-buffer))
-			 )))
-		)))
+						   (match-end 0))))
+			 (kill-buffer (current-buffer))))))))
       (if (and total (> total 0)
 	       (>= (length (directory-files root-dir nil "^[0-9]+$" t))
 		   total))
@@ -456,8 +434,7 @@ occurs."
 		(while (<= i total)
 		  (setq file (concat root-dir "/" (int-to-string i)))
 		  (or (file-exists-p file)
-		      (throw 'tag nil)
-		      )
+		      (throw 'tag nil))
 		  (binary-insert-encoded-file file)
 		  (goto-char (point-max))
 		  (setq i (1+ i))))
@@ -483,9 +460,7 @@ occurs."
 		  (make-local-variable 'mime-view-temp-message-buffer)
 		  (setq mime-view-temp-message-buffer buf))
 		(set-window-buffer pwin pbuf)
-		(select-window pwin)
-		))))
-      )))
+		(select-window pwin))))))))
 
 
 ;;; @ message/external-body
@@ -494,15 +469,13 @@ occurs."
 (defvar mime-raw-dired-function
   (if window-system
       (function dired-other-frame)
-    (function mime-raw-dired-function-for-one-frame)
-    ))
+    (function mime-raw-dired-function-for-one-frame)))
 
 (defun mime-raw-dired-function-for-one-frame (dir)
   (let ((win (or (get-buffer-window mime-preview-buffer)
 		 (get-largest-window))))
     (select-window win)
-    (dired dir)
-    ))
+    (dired dir)))
 
 (defun mime-view-message/external-anon-ftp (_entity cal)
   (let* ((site (cdr (assoc "site" cal)))
@@ -512,8 +485,7 @@ occurs."
     (message "%s" (concat "Accessing " (expand-file-name name pathname) "..."))
     (funcall mime-raw-dired-function pathname)
     (goto-char (point-min))
-    (search-forward name)
-    ))
+    (search-forward name)))
 
 (defvar mime-raw-browse-url-function mime-browse-url-function)
 
@@ -535,15 +507,12 @@ occurs."
       (erase-buffer)
       (mime-insert-text-content entity)
       (mule-caesar-region (point-min) (point-max))
-      (set-buffer-modified-p nil)
-      )
+      (set-buffer-modified-p nil))
     (let ((win (get-buffer-window (current-buffer))))
       (or (eq (selected-window) win)
-	  (select-window (or win (get-largest-window)))
-	  ))
+	  (select-window (or win (get-largest-window)))))
     (view-buffer buf)
-    (goto-char (point-min))
-    ))
+    (goto-char (point-min))))
 
 
 ;;; @ end

--- a/mime-setup.el
+++ b/mime-setup.el
@@ -28,13 +28,11 @@
 
 (condition-case nil
     (load "gnus-mime-setup")
-  (error (message "gnus-mime-setup is not found."))
-  )
+  (error (message "gnus-mime-setup is not found.")))
 
 (condition-case nil
     (load "emh-setup")
-  (error (message "emh-setup is not found."))
-  )
+  (error (message "emh-setup is not found.")))
 
 
 ;;; @ end

--- a/mime-tnef.el
+++ b/mime-tnef.el
@@ -572,8 +572,7 @@
     (+ (mime-tnef-byte array idx)
        (* (mime-tnef-byte array (1+ idx)) 256)
        (* (mime-tnef-byte array (+ idx 2)) 65536)
-       (* (mime-tnef-byte array (+ idx 3)) 16777216)))
-  )
+       (* (mime-tnef-byte array (+ idx 3)) 16777216))))
 
 
 ;;; Debug
@@ -743,12 +742,10 @@
 		  (setq read (+ read 4 (mime-tnef-padded-length length)))))
 	       (t
 		(message "TNEF may be corrupted!!")
-		(throw :done (nreverse result)))
-	       ))
+		(throw :done (nreverse result)))))
 	    (setq result
 		  (cons `((name . ,name) (type . ,type) (values . ,values))
-			result))
-	    )))
+			result)))))
       (nreverse result))))
 
 (defun mime-tnef-mapi-string (mapi-element tnef)
@@ -776,8 +773,7 @@
 	  (mime-tnef-debug "Multiple ATTACHDATA for single ATTACHRENDDATA"))
 	(setq file (append
 		    `(,(assq 'start (car elements))
-		      ,(assq 'end (car elements))
-		      )
+		      ,(assq 'end (car elements)))
 		    (delq (assq 'start file)
 			  (delq (assq 'end file) file)))))
        ((eq type 'ATTACHTITLE)
@@ -803,8 +799,7 @@
 		;; ATTACH_LONG_FILENAME is preferred.
 		(unless (assq 'longname file)
 		  (setq file (cons `(name . ,(mime-tnef-mapi-string elt tnef))
-				   (delq (assq 'name file) file)))))
-	       ))
+				   (delq (assq 'name file) file)))))))
 	    (setq mapi (cdr mapi))))))
       (setq elements (cdr elements)))
     (delq nil (nreverse (cons file files)))))
@@ -858,8 +853,7 @@
        (goto-char (point-min))
        (mime-tnef-translate-single-part-tag)
        (buffer-string)))
-    (insert data "\n")
-    ))
+    (insert data "\n")))
 
 (defun mime-tnef-translate-single-part-tag ()
   (if (re-search-forward mime-edit-single-part-tag-regexp nil t)
@@ -878,8 +872,7 @@
 	  (cons (and contype
 		     (downcase contype))
 		(and encoding
-		     (downcase encoding))))
-	)))
+		     (downcase encoding)))))))
 
 (defvar mime-tnef-buffers nil)
 
@@ -933,8 +926,7 @@
 	(mime-display-entity
 	 tnef-entity nil '((header . invisible)
 			   (body . visible)
-			   (entity-button . invisible))))
-      )))
+			   (entity-button . invisible)))))))
 
 ;;; @ end
 ;;;

--- a/mime-view.el
+++ b/mime-view.el
@@ -114,8 +114,7 @@ multipart/multilingual entities. See docstring of
   `(("original" . 2)
     ("human" . 1)
     ("automated" . -1)
-    (,mime-display-multipart/multilingual-unknown-translation-type . 0)
-    )
+    (,mime-display-multipart/multilingual-unknown-translation-type . 0))
   "Specify scores Content-Translation-Type: header fields.  When
 score is negative value, corresponding entity is not displayed
 automatically.  If field calue is missing or field does not
@@ -187,8 +186,7 @@ Each element is a list consists of required module, previewer function and requi
 (defvar mime-raw-representation-type-alist
   '((mime-show-message-mode     . binary)
     (mime-temp-message-mode     . binary)
-    (t                          . cooked)
-    )
+    (t                          . cooked))
   "Alist of major-mode vs. representation-type of mime-raw-buffer.
 Each element looks like (SYMBOL . REPRESENTATION-TYPE).  SYMBOL is
 major-mode or t.  t means default.  REPRESENTATION-TYPE must be
@@ -219,8 +217,7 @@ mime-mother-buffer, it returns original major-mode of the
 mother-buffer."
   (if (and recursive mime-mother-buffer)
       (with-current-buffer mime-mother-buffer
-	(mime-preview-original-major-mode recursive)
-	)
+	(mime-preview-original-major-mode recursive))
     (cdr (assq 'major-mode
 	       (get-text-property (or point
 				      (if (> (point) (buffer-size))
@@ -240,15 +237,13 @@ mother-buffer."
       (setq rest (or (mime-entity-content-type entity)
 		     (make-mime-content-type 'text 'plain))
 	    situation (cons (car rest) situation)
-	    rest (cdr rest))
-      )
+	    rest (cdr rest)))
     (unless (assq 'subtype situation)
       (or rest
 	  (setq rest (or (cdr (mime-entity-content-type entity))
 			 '((subtype . plain)))))
       (setq situation (cons (car rest) situation)
-	    rest (cdr rest))
-      )
+	    rest (cdr rest)))
     (while rest
       (setq param (car rest))
       (or (assoc (car param) situation)
@@ -263,8 +258,7 @@ mother-buffer."
 	  (setq situation (cons (cons 'disposition-type
 				      (mime-content-disposition-type rest))
 				situation)
-		rest (mime-content-disposition-parameters rest))
-	))
+		rest (mime-content-disposition-parameters rest))))
     (while rest
       (setq param (car rest)
 	    name (car param))
@@ -314,8 +308,7 @@ mother-buffer."
 	     (cell (assq field situation)))
 	(if cell
 	    (or (memq (cdr cell) ignored-values)
-		(setq dest (cons situation dest))
-		)))
+		(setq dest (cons situation dest)))))
       (setq situations (cdr situations)))
     dest))
 
@@ -329,13 +322,9 @@ mother-buffer."
 	(when ecell
 	  (if (equal cell ecell)
 	      (setq match (1+ match))
-	    (setq example (delq ecell example))
-	    ))
-	)
-      (setq situation (cdr situation))
-      )
-    (cons match example)
-    ))
+	    (setq example (delq ecell example)))))
+      (setq situation (cdr situation)))
+    (cons match example)))
 
 (defun mime-sort-situation (situation)
   (sort situation
@@ -347,30 +336,23 @@ mother-buffer."
 			   (mode . 3)
 			   (method . 4)
 			   (major-mode . 5)
-			   (disposition-type . 6)
-			   ))
+			   (disposition-type . 6)))
 		  a-order b-order)
 	      (if (symbolp a-t)
 		  (let ((ret (assq a-t order)))
 		    (if ret
 			(setq a-order (cdr ret))
-		      (setq a-order 7)
-		      ))
-		(setq a-order 8)
-		)
+		      (setq a-order 7)))
+		(setq a-order 8))
 	      (if (symbolp b-t)
 		  (let ((ret (assq b-t order)))
 		    (if ret
 			(setq b-order (cdr ret))
-		      (setq b-order 7)
-		      ))
-		(setq b-order 8)
-		)
+		      (setq b-order 7)))
+		(setq b-order 8))
 	      (if (= a-order b-order)
 		  (string< (format "%s" a-t)(format "%s" b-t))
-		(< a-order b-order))
-	      )))
-  )
+		(< a-order b-order))))))
 
 (defun mime-unify-situations (entity-situation
 			      condition situation-examples
@@ -403,21 +385,18 @@ mother-buffer."
 			     (setq max-score ret-score
 				   max-escore (cdar examples)
 				   max-examples (list (cdr ret))
-				   max-situations (list situation))
-			     )
+				   max-situations (list situation)))
 			    ((= ret-score max-score)
 			     (cond ((> (cdar examples) max-escore)
 				    (setq max-escore (cdar examples)
 					  max-examples (list (cdr ret))
-					  max-situations (list situation))
-				    )
+					  max-situations (list situation)))
 				   ((= (cdar examples) max-escore)
 				    (setq max-examples
 					  (cons (cdr ret) max-examples))
 				    (or (member situation max-situations)
 					(setq max-situations
-					      (cons situation max-situations)))
-				    )))))
+					      (cons situation max-situations))))))))
 		    (setq examples (cdr examples))))
 		(setq rest (cdr rest)))
 	      (when max-situations
@@ -430,10 +409,8 @@ mother-buffer."
 			(setcdr cell (1+ (cdr cell)))
 		      (setq situation-examples
 			    (cons (cons example 0)
-				  situation-examples))
-		      ))
-		  (setq max-examples (cdr max-examples))
-		  )))))
+				  situation-examples))))
+		  (setq max-examples (cdr max-examples)))))))
     (cons ret situation-examples)
     ;; ret: list of situations
     ;; situation-examples: new examples (notoce that contents of
@@ -580,8 +557,7 @@ mother-buffer."
 		       min-freq freq
 		       d-i i
 		       d-j j
-		       dest (cons (cdr ret) freq))
-		 )
+		       dest (cons (cdr ret) freq)))
 		((= max-sim sim)
 		 (cond ((> min-det-ret det-ret)
 			(setq min-det-ret det-ret
@@ -589,27 +565,20 @@ mother-buffer."
 			      min-freq freq
 			      d-i i
 			      d-j j
-			      dest (cons (cdr ret) freq))
-			)
+			      dest (cons (cdr ret) freq)))
 		       ((= min-det-ret det-ret)
 			(cond ((> min-det-org det-org)
 			       (setq min-det-org det-org
 				     min-freq freq
 				     d-i i
 				     d-j j
-				     dest (cons (cdr ret) freq))
-			       )
+				     dest (cons (cdr ret) freq)))
 			      ((= min-det-org det-org)
 			       (cond ((> min-freq freq)
 				      (setq min-freq freq
 					    d-i i
 					    d-j j
-					    dest (cons (cdr ret) freq))
-				      ))
-			       ))
-			))
-		 ))
-	  )
+					    dest (cons (cdr ret) freq)))))))))))
 	(setq jr (cdr jr)
 	      j (1+ j)))
       (setq ir (cdr ir)
@@ -624,8 +593,7 @@ mother-buffer."
 	(setq situation-examples
 	      (cdr situation-examples))
       (setq ir (nthcdr (1- d-i) situation-examples))
-      (setcdr ir (cddr ir))
-      )
+      (setcdr ir (cddr ir)))
     (if (setq ir (assoc (car dest) situation-examples))
 	(progn
 	  (setcdr ir (+ (cdr ir)(cdr dest)))
@@ -674,11 +642,9 @@ mother-buffer."
 		    (if (consp entity-node-id)
 			(mapconcat (function
 				    (lambda (num)
-				      (format "%s" (1+ num))
-				      ))
+				      (format "%s" (1+ num))))
 				   (reverse entity-node-id) ".")
-		      "0"))
-		))
+		      "0"))))
        (cond (access-type
 	      (let ((server (assoc "server" params)))
 		(setq access-type (cdr access-type))
@@ -687,15 +653,12 @@ mother-buffer."
 			    num subject access-type (cdr server))
 		(let ((site (cdr (assoc "site" params)))
 		      (dir (cdr (assoc "directory" params)))
-		      (url (cdr (assoc "url" params)))
-		      )
+		      (url (cdr (assoc "url" params))))
 		  (if url
 		      (format "%s %s ([%s] %s)"
 			      num subject access-type url)
 		    (format "%s %s ([%s] %s:%s)"
-			    num subject access-type site dir))
-		  )))
-	    )
+			    num subject access-type site dir))))))
 	   (t
 	    (let* ((charset (cdr (assoc "charset" params)))
 		   (encoding (mime-entity-encoding entity))
@@ -717,10 +680,8 @@ mother-buffer."
 	       num " " subject
 	       (if (>= (+ (current-column)(length rest))(window-width))
 		   "\n\t")
-	       rest))
-	    )))
-     (function mime-preview-play-current-entity))
-    ))
+	       rest)))))
+     (function mime-preview-play-current-entity))))
 
 
 ;;; @@ entity-header
@@ -758,8 +719,7 @@ Each elements are regexp of field-name.")
 							field-type field-value)
   (let ((s-field (assq field-type calist)))
     (cond ((null s-field)
-	   (cons (cons field-type field-value) calist)
-	   )
+	   (cons (cons field-type field-value) calist))
 	  (t calist))))
 
 (define-calist-field-match-method
@@ -938,8 +898,7 @@ Each elements are regexp of field-name.")
 	 ;; Stuffed or normal line
 	 ((looking-at " ?\\(.*?\\)\\( ?\\)$")
 	  (list 0 (if (zerop (length (match-string 2))) t nil)
-		(match-beginning 1)))
-	 )))
+		(match-beginning 1))))))
 
 (defun mime-display-text/plain-flowed (&optional buffer delete-space)
   (with-current-buffer (or (current-buffer) buffer)
@@ -997,8 +956,7 @@ Each elements are regexp of field-name.")
 	    ;; Beginnig of flowed text
 	    (setq beg-flow (car line)
 		  depth (nth 1 line))))
-	(setq line next)
-	))))
+	(setq line next)))))
 
 (defun mime-display-text/plain (entity situation)
   (save-restriction
@@ -1006,16 +964,14 @@ Each elements are regexp of field-name.")
     (when (mime-display-insert-text-content entity)
       (when (null (eq (char-before (point-max)) ?\n))
 	(goto-char (point-max))
-	(insert "\n")
-	)
+	(insert "\n"))
       (when (equal (downcase (or (cdr (assoc "format" situation)) ""))
 		   "flowed")
 	(mime-display-text/plain-flowed
 	 nil (equal (downcase (or (cdr (assoc "delsp" situation)) ""))
 		    "yes")))
       (mime-add-url-buttons)
-      (run-hooks 'mime-display-text/plain-hook)
-      )))
+      (run-hooks 'mime-display-text/plain-hook))))
 
 (autoload 'richtext-decode "richtext")
 
@@ -1024,16 +980,14 @@ Each elements are regexp of field-name.")
     (narrow-to-region (point-max)(point-max))
     (when (mime-display-insert-text-content entity)
       (remove-text-properties (point-min) (point-max) '(face nil))
-      (richtext-decode (point-min) (point-max))
-      )))
+      (richtext-decode (point-min) (point-max)))))
 
 (defun mime-display-text/enriched (entity _situation)
   (save-restriction
     (narrow-to-region (point-max)(point-max))
     (when (mime-display-insert-text-content entity)
       (remove-text-properties (point-min) (point-max) '(face nil))
-      (enriched-decode (point-min) (point-max))
-      )))
+      (enriched-decode (point-min) (point-max)))))
 
 (defun mime-display-text/html-previewer-params ()
   (and mime-view-text/html-previewer
@@ -1060,21 +1014,18 @@ Each elements are regexp of field-name.")
 \[[ or click here by mouse button-2.             ]]"
     "\
 \[[ This is message/partial style split message. ]]
-\[[ Please press `v' key in this buffer.         ]]"
-    ))
+\[[ Please press `v' key in this buffer.         ]]"))
 
 (defun mime-display-message/partial-button (&optional _entity _situation)
   (save-restriction
     (goto-char (point-max))
     (if (not (search-backward "\n\n" nil t))
-	(insert "\n")
-      )
+	(insert "\n"))
     (goto-char (point-max))
     (narrow-to-region (point-max)(point-max))
     (insert mime-view-announcement-for-message/partial)
     (mime-add-button (point-min)(point-max)
-		     #'mime-preview-play-current-entity)
-    ))
+		     #'mime-preview-play-current-entity)))
 
 (defun mime-display-message/rfc822 (entity situation)
   (let ((child (car (mime-entity-children entity)))
@@ -1099,8 +1050,7 @@ Each elements are regexp of field-name.")
 	      (cons original-major-mode-cell default-situation)))
     (while children
       (mime-display-entity (car children) nil default-situation)
-      (setq children (cdr children))
-      )))
+      (setq children (cdr children)))))
 
 (defvar mime-view-entity-lowest-score -1)
 
@@ -1109,8 +1059,7 @@ Each elements are regexp of field-name.")
     ((text . richtext) . 2)
     ((text . plain)    . 1)
     ((text . html)     . mime-view-text/html-entity-score)
-    (multipart . mime-view-multipart-entity-score)
-    )
+    (multipart . mime-view-multipart-entity-score))
   "Alist MEDIA-TYPE vs corresponding score.
 MEDIA-TYPE must be (TYPE . SUBTYPE), TYPE or t.  t means default.
 If MEDIA-TYPE does not have corresponding score, `mime-view-entity-lowest-score' is used.
@@ -1135,8 +1084,7 @@ Score is integer or function or variable.  The function receives entity and retu
 		     mime-view-type-subtype-score-alist)
 	      (assq (cdr (assq 'type situation))
 		    mime-view-type-subtype-score-alist)
-	      (assq t mime-view-type-subtype-score-alist)
-	      ))))
+	      (assq t mime-view-type-subtype-score-alist)))))
     (cond
      ((functionp score)
       (setq score (funcall score entity)))
@@ -1144,8 +1092,7 @@ Score is integer or function or variable.  The function receives entity and retu
       (setq score (symbol-value score))))
     (if (numberp score)
 	score
-      mime-view-entity-lowest-score)
-    ))
+      mime-view-entity-lowest-score)))
 
 (defun mime-view-multipart-entity-score (entity)
   (apply 'max (or (mapcar 'mime-view-entity-score
@@ -1196,8 +1143,7 @@ Score is integer or function or variable.  The function receives entity and retu
 	       (setq score (mime-view-entity-score child child-situation))
 	       (when (>= score max-score)
 		 (setq p child
-		       max-score score)
-		 ))
+		       max-score score)))
 	     (cons child child-situation))
 	   (mime-entity-children entity)))
     (or p (setq p (caar pairs)))
@@ -1213,8 +1159,7 @@ Score is integer or function or variable.  The function receives entity and retu
 			  'mime-view-multipart-descendant-button
 			  (copy-alist (cdr pair))))
 	      (t (put-alist 'body 'invisible (copy-alist (cdr pair)))))))
-	  pairs)
-    ))
+	  pairs)))
 
 (defun mime-display-multipart/related (entity situation)
   (let* ((param-start (mime-parse-msg-id
@@ -1350,8 +1295,7 @@ part (if exist) or the first language message part."
 	       (put-alist 'body 'invisible
 			  (copy-alist (mime-find-entity-preview-situation
 				       child default-situation))))))
-	  (mime-entity-children entity))
-    ))
+	  (mime-entity-children entity))))
 
 ;;; @ acting-condition
 ;;;
@@ -1381,8 +1325,7 @@ part (if exist) or the first language message part."
 	    (cond ((eq field-type 'view)  (setq view field))
 		  ((eq field-type 'print) (setq print field))
 		  ((memq field-type '(compose composetyped edit)))
-		  (t (setq shared (cons field shared))))
-	    )
+		  (t (setq shared (cons field shared)))))
 	  (setq entry (cdr entry)))
 	(setq shared (nreverse shared))
 	(ctree-set-calist-with-default
@@ -1401,8 +1344,7 @@ part (if exist) or the first language message part."
  'mime-acting-condition
  '((type . application)(subtype . octet-stream)
    (mode . "play")
-   (method . mime-detect-content)
-   ))
+   (method . mime-detect-content)))
 
 (ctree-set-calist-with-default
  'mime-acting-condition
@@ -1412,44 +1354,37 @@ part (if exist) or the first language message part."
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . text)(subtype . x-rot13-47)(mode . "play")
-   (method . mime-view-caesar)
-   ))
+   (method . mime-view-caesar)))
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . text)(subtype . x-rot13-47-48)(mode . "play")
-   (method . mime-view-caesar)
-   ))
+   (method . mime-view-caesar)))
 
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . message)(subtype . rfc822)(mode . "play")
-   (method . mime-view-message/rfc822)
-   ))
+   (method . mime-view-message/rfc822)))
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . message)(subtype . partial)(mode . "play")
-   (method . mime-store-message/partial-piece)
-   ))
+   (method . mime-store-message/partial-piece)))
 
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . message)(subtype . external-body)
    ("access-type" . "anon-ftp")
-   (method . mime-view-message/external-anon-ftp)
-   ))
+   (method . mime-view-message/external-anon-ftp)))
 
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . message)(subtype . external-body)
    ("access-type" . "url")
-   (method . mime-view-message/external-url)
-   ))
+   (method . mime-view-message/external-url)))
 
 (ctree-set-calist-strictly
  'mime-acting-condition
  '((type . application)(subtype . octet-stream)
-   (method . mime-save-content)
-   ))
+   (method . mime-save-content)))
 
 
 ;;; @ quitting method
@@ -1564,8 +1499,7 @@ part (if exist) or the first language message part."
 		 (cdr (assq 'body-presentation-method situation))))
 	    (if (functionp body-presentation-method)
 		(funcall body-presentation-method entity situation)
-	      (mime-display-multipart/mixed entity situation))))
-      )))
+	      (mime-display-multipart/mixed entity situation)))))))
 
 
 ;;; @ MIME viewer mode
@@ -1580,8 +1514,7 @@ part (if exist) or the first language message part."
     (scroll-up	 "Scroll-up"               mime-preview-scroll-up-entity)
     (play	 "Play current entity"     mime-preview-play-current-entity)
     (extract	 "Extract current entity"  mime-preview-extract-current-entity)
-    (print	 "Print current entity"    mime-preview-print-current-entity)
-    )
+    (print	 "Print current entity"    mime-preview-print-current-entity))
   "Menu for MIME Viewer")
 
 (defvar mime-view-popup-menu
@@ -1679,8 +1612,7 @@ part (if exist) or the first language message part."
 	      (append mime-view-mode-map (list (cons t default)))))
     (if mouse-button-2
 	(define-key mime-view-mode-map
-	  mouse-button-2 (function mime-button-dispatcher))
-      )
+	  mouse-button-2 (function mime-button-dispatcher)))
     (define-key mime-view-mode-map
       mouse-button-3 (function mime-view-popup-menu))
     (define-key mime-view-mode-map [menu-bar mime-view]
@@ -1690,8 +1622,7 @@ part (if exist) or the first language message part."
 	   (lambda (item)
 	     (define-key mime-view-mode-map
 	       (vector 'menu-bar 'mime-view (car item))
-	       (cons (nth 1 item)(nth 2 item)))
-	     ))
+	       (cons (nth 1 item)(nth 2 item)))))
 	  (reverse mime-view-menu-list))
 
     ;; (run-hooks 'mime-view-define-keymap-hook)
@@ -1708,10 +1639,8 @@ part (if exist) or the first language message part."
 	  (erase-buffer)
 	  (let ((win (get-buffer-window buf)))
 	    (if win
-		(delete-window win)
-	      ))
-	  (bury-buffer buf)
-	  ))))
+		(delete-window win)))
+	  (bury-buffer buf)))))
 
 (defvar mime-view-redisplay nil)
 
@@ -1803,11 +1732,9 @@ message.  It must be nil, `binary' or `cooked'.  If it is nil,
 	    (save-excursion
 	      (set-buffer raw-buffer)
 	      (cdr (or (assq major-mode mime-raw-representation-type-alist)
-		       (assq t mime-raw-representation-type-alist)))
-	      )))
+		       (assq t mime-raw-representation-type-alist))))))
   (if (eq representation-type 'binary)
-      (setq representation-type 'buffer)
-    )
+      (setq representation-type 'buffer))
   (setq preview-buffer (mime-display-message
 			(mime-open-entity representation-type raw-buffer)
 			preview-buffer mother default-keymap-or-function))
@@ -1818,8 +1745,7 @@ message.  It must be nil, `binary' or `cooked'.  If it is nil,
 	  (let ((m-win (and mother (get-buffer-window mother))))
 	    (if m-win
 		(set-window-buffer m-win preview-buffer)
-	      (switch-to-buffer preview-buffer)
-	      ))))))
+	      (switch-to-buffer preview-buffer)))))))
 
 (defun mime-view-mode (&optional mother ctl encoding
 				 raw-buffer preview-buffer
@@ -1856,18 +1782,14 @@ button-2	Move to point under the mouse cursor
 		(or (assq major-mode mime-raw-representation-type-alist)
 		    (assq t mime-raw-representation-type-alist)))))
 	  (if (eq type 'binary)
-	      (setq type 'buffer)
-	    )
+	      (setq type 'buffer))
 	  (setq message (mime-open-entity type raw-buffer))
 	  (or (mime-entity-content-type message)
-	      (mime-entity-set-content-type message ctl))
-	  )
+	      (mime-entity-set-content-type message ctl)))
 	(or (mime-entity-encoding message)
-	    (mime-entity-set-encoding message encoding))
-	))
+	    (mime-entity-set-encoding message encoding))))
     (mime-display-message message preview-buffer
-			  mother default-keymap-or-function)
-    ))
+			  mother default-keymap-or-function)))
 
 
 ;;; @@ utility
@@ -1893,19 +1815,15 @@ If WITH-CHILDREN, refer boundary surrounding current part and its branches."
 						      'mime-view-entity)
 			 (point))
 		     (point)
-		   (point-min)))
-	   )
+		   (point-min))))
 	  ((eq (next-single-property-change p-beg 'mime-view-entity)
 	       (point))
-	   (setq p-beg (point))
-	   ))
+	   (setq p-beg (point))))
     (setq p-end (next-single-property-change p-beg 'mime-view-entity))
     (cond ((null p-end)
-	   (setq p-end (point-max))
-	   )
+	   (setq p-end (point-max)))
 	  ((null entity-node-id)
-	   (setq p-end (point-max))
-	   )
+	   (setq p-end (point-max)))
 	  (with-children
 	   (save-excursion
 	     (catch 'tag
@@ -1923,8 +1841,7 @@ If WITH-CHILDREN, refer boundary surrounding current part and its branches."
 		   (setq p-end (or (next-single-property-change
 				    (point) 'mime-view-entity)
 				   (point-max)))))
-	       (setq p-end (point-max))))
-	   ))
+	       (setq p-end (point-max))))))
     (vector p-beg p-end entity)))
 
 
@@ -1940,8 +1857,7 @@ It decodes current entity to call internal or external method as
 \"extract\" mode.  The method is selected from variable
 `mime-acting-condition'."
   (interactive "P")
-  (mime-preview-play-current-entity ignore-examples "extract")
-  )
+  (mime-preview-play-current-entity ignore-examples "extract"))
 
 (defun mime-preview-print-current-entity (&optional ignore-examples)
   "Print current entity (maybe).
@@ -1949,8 +1865,7 @@ It decodes current entity to call internal or external method as
 \"print\" mode.  The method is selected from variable
 `mime-acting-condition'."
   (interactive "P")
-  (mime-preview-play-current-entity ignore-examples "print")
-  )
+  (mime-preview-play-current-entity ignore-examples "print"))
 
 
 ;;; @@ following
@@ -2004,8 +1919,7 @@ It calls following-method selected from variable
 			(mime-insert-header current-entity fields)
 			t))
 	    (setq fields (std11-collect-field-names)
-		  current-entity (mime-entity-parent current-entity))
-	    ))
+		  current-entity (mime-entity-parent current-entity))))
 	(let ((rest mime-view-following-required-fields-list)
 	      field-name ret)
 	  (while rest
@@ -2022,19 +1936,14 @@ It calls following-method selected from variable
 						   entity field-name))))
 			(setq entity (mime-entity-parent entity)))))
 		  (if ret
-		      (insert field-name ": " ret "\n")
-		    )))
-	    (setq rest (cdr rest))
-	    ))
-	)
+		      (insert field-name ": " ret "\n"))))
+	    (setq rest (cdr rest)))))
       (let ((f (cdr (assq mode mime-preview-following-method-alist))))
 	(if (functionp f)
 	    (funcall f new-buf)
 	  (message
 	   "Sorry, following method for %s is not implemented yet."
-	   mode)
-	  ))
-      )))
+	   mode))))))
 
 
 ;;; @@ moving
@@ -2047,8 +1956,7 @@ If there is no upper entity, call function `mime-preview-quit'."
   (let (cinfo)
     (while (null (setq cinfo
 		       (get-text-property (point) 'mime-view-entity)))
-      (backward-char)
-      )
+      (backward-char))
     (let ((r (mime-entity-parent cinfo))
 	  point)
       (catch 'tag
@@ -2065,11 +1973,8 @@ If there is no upper entity, call function `mime-preview-quit'."
 			       (beginning-of-line)
 			       (point)))))
 		(recenter next-screen-context-lines))
-	    (throw 'tag t)
-	    )
-	  )
-	(mime-preview-quit)
-	))))
+	    (throw 'tag t)))
+	(mime-preview-quit)))))
 
 (defun mime-preview-move-to-previous ()
   "Move to previous entity.
@@ -2078,8 +1983,7 @@ variable `mime-preview-over-to-previous-method-alist'."
   (interactive)
   (while (and (not (bobp))
 	      (null (get-text-property (point) 'mime-view-entity)))
-    (backward-char)
-    )
+    (backward-char))
   (let ((point (previous-single-property-change (point) 'mime-view-entity)))
     (if (and point
 	     (>= point (point-min)))
@@ -2096,14 +2000,11 @@ variable `mime-preview-over-to-previous-method-alist'."
 				  (point)))))
 			(recenter (* -1 next-screen-context-lines))))
 	  (goto-char (1- point))
-	  (mime-preview-move-to-previous)
-	  )
+	  (mime-preview-move-to-previous))
       (let ((f (assq (mime-preview-original-major-mode)
 		     mime-preview-over-to-previous-method-alist)))
 	(if f
-	    (funcall (cdr f))
-	  ))
-      )))
+	    (funcall (cdr f)))))))
 
 (defun mime-preview-move-to-next ()
   "Move to next entity.
@@ -2112,8 +2013,7 @@ variable `mime-preview-over-to-next-method-alist'."
   (interactive)
   (while (and (not (eobp))
 	      (null (get-text-property (point) 'mime-view-entity)))
-    (forward-char)
-    )
+    (forward-char))
   (let ((point (next-single-property-change (point) 'mime-view-entity)))
     (if (and point
 	     (<= point (point-max)))
@@ -2131,14 +2031,11 @@ variable `mime-preview-over-to-next-method-alist'."
 			    (* -1 next-screen-context-lines))
 			   (beginning-of-line)
 			   (point)))))
-		 (recenter next-screen-context-lines))
-	    ))
+		 (recenter next-screen-context-lines))))
       (let ((f (assq (mime-preview-original-major-mode)
 		     mime-preview-over-to-next-method-alist)))
 	(if f
-	    (funcall (cdr f))
-	  ))
-      )))
+	    (funcall (cdr f)))))))
 
 (defun mime-preview-scroll-up-entity (&optional h)
   "Scroll up current entity.
@@ -2149,8 +2046,7 @@ If reached to (point-max), it calls function registered in variable
       (let ((f (assq (mime-preview-original-major-mode)
 		     mime-preview-over-to-next-method-alist)))
 	(if f
-	    (funcall (cdr f))
-	  ))
+	    (funcall (cdr f))))
     (let ((point
 	   (or (next-single-property-change (point) 'mime-view-entity)
 	       (point-max)))
@@ -2162,8 +2058,7 @@ If reached to (point-max), it calls function registered in variable
 	(condition-case nil
 	    (scroll-up h)
 	  (end-of-buffer
-	   (goto-char (point-max)))))
-      )))
+	   (goto-char (point-max))))))))
 
 (defun mime-preview-scroll-down-entity (&optional h)
   "Scroll down current entity.
@@ -2174,8 +2069,7 @@ If reached to (point-min), it calls function registered in variable
       (let ((f (assq (mime-preview-original-major-mode)
 		     mime-preview-over-to-previous-method-alist)))
 	(if f
-	    (funcall (cdr f))
-	  ))
+	    (funcall (cdr f))))
     (let ((point
 	   (or (previous-single-property-change (point) 'mime-view-entity)
 	       (point-min)))
@@ -2187,22 +2081,19 @@ If reached to (point-min), it calls function registered in variable
 	(condition-case nil
 	    (scroll-down h)
 	  (beginning-of-buffer
-	   (goto-char (point-min)))))
-      )))
+	   (goto-char (point-min))))))))
 
 (defun mime-preview-next-line-entity (&optional lines)
   "Scroll up one line (or prefix LINES lines).
 If LINES is negative, scroll down LINES lines."
   (interactive "p")
-  (mime-preview-scroll-up-entity (or lines 1))
-  )
+  (mime-preview-scroll-up-entity (or lines 1)))
 
 (defun mime-preview-previous-line-entity (&optional lines)
   "Scrroll down one line (or prefix LINES lines).
 If LINES is negative, scroll up LINES lines."
   (interactive "p")
-  (mime-preview-scroll-down-entity (or lines 1))
-  )
+  (mime-preview-scroll-down-entity (or lines 1)))
 
 
 ;;; @@ display
@@ -2274,13 +2165,11 @@ It calls function registered in variable
   (let ((r (assq (mime-preview-original-major-mode)
 		 mime-preview-quitting-method-alist)))
     (if r
-	(funcall (cdr r))
-      )))
+	(funcall (cdr r)))))
 
 (defun mime-preview-kill-buffer ()
   (interactive)
-  (kill-buffer (current-buffer))
-  )
+  (kill-buffer (current-buffer)))
 
 
 ;;; @ end

--- a/mime-w3.el
+++ b/mime-w3.el
@@ -49,8 +49,7 @@
        (condition-case err
 	   (w3-region p (point-max))
 	 (error (message "%s" err)))
-       (mime-put-keymap-region p (point-max) w3-mode-map)
-       ))))
+       (mime-put-keymap-region p (point-max) w3-mode-map)))))
 
 (defun url-cid (url &optional proxy-info)
   (let ((entity

--- a/semi-def.el
+++ b/semi-def.el
@@ -63,16 +63,14 @@
        (put-text-property from to 'mouse-face mime-button-mouse-face))
   (put-text-property from to 'mime-button-callback function)
   (and data
-       (put-text-property from to 'mime-button-data data))
-  )
+       (put-text-property from to 'mime-button-data data)))
 
 (defsubst mime-insert-button (string function &optional data)
   "Insert STRING as button with callback FUNCTION and DATA."
   (save-restriction
     (narrow-to-region (point)(point))
     (insert "[" string "]\n")
-    (mime-add-button (point-min)(point-max) function data)
-    ))
+    (mime-add-button (point-min)(point-max) function data)))
 
 (defvar mime-button-mother-dispatcher nil)
 
@@ -85,8 +83,7 @@
       (setq buf (current-buffer)
 	    point (point)
 	    func (get-text-property (point) 'mime-button-callback)
-	    data (get-text-property (point) 'mime-button-data)
-	    ))
+	    data (get-text-property (point) 'mime-button-data)))
     ;; Do not use `with-current-buffer'.
     ;; buf may be the current buffer.
     (save-excursion
@@ -95,8 +92,7 @@
       (if func
 	  (apply func data)
 	(if (fboundp mime-button-mother-dispatcher)
-	    (funcall mime-button-mother-dispatcher event)
-	  )))))
+	    (funcall mime-button-mother-dispatcher event))))))
 
 
 ;;; @ for URL
@@ -172,12 +168,9 @@ activate."
 		    (mapc (lambda (parameter)
 			    (when (setq func (cdr (assq parameter condition)))
 			      (autoload func file)))
-			  '(method body-presentation-method)))
-		)
-	    (error "Function for mode `%s' is not found." mode)
-	    ))
-      (error "Variable for target-type `%s' is not found." target-type)
-      )))
+			  '(method body-presentation-method))))
+	    (error "Function for mode `%s' is not found." mode)))
+      (error "Variable for target-type `%s' is not found." target-type))))
 
 
 ;;; @ end

--- a/semi-setup.el
+++ b/semi-setup.el
@@ -35,10 +35,8 @@ it is used as hook to set."
   (if (featurep module)
       (funcall func)
     (or hook-name
-	(setq hook-name (intern (concat (symbol-name module) "-load-hook")))
-	)
-    (add-hook hook-name func)
-    ))
+	(setq hook-name (intern (concat (symbol-name module) "-load-hook"))))
+    (add-hook hook-name func)))
 
 
 ;; for image/*
@@ -87,8 +85,7 @@ it is used as hook to set."
 	     
 	     (set-alist 'mime-view-type-subtype-score-alist
 			`(text . ,subtype) 3))
-	   '(vcard x-vcard))
-     ))
+	   '(vcard x-vcard))))
 
 ;; for PGP
 (defvar mime-setup-enable-epg t
@@ -194,9 +191,7 @@ it is used as hook to set."
 	(subtype . x-pkcs7-signature)
 	(body . mime-pgp-verify-when-preview)
 	(body-presentation-method . mime-preview-application/*-signature))
-      'strict "mime-pgp")
-     )
-  )
+      'strict "mime-pgp")))
 
 
 (eval-after-load "mime-view"
@@ -214,8 +209,7 @@ it is used as hook to set."
 	(subtype . vnd.ms-tnef)
 	(body . visible)
 	(body-presentation-method . mime-display-application/ms-tnef))
-      'strict "mime-tnef")
-     ))
+      'strict "mime-tnef")))
 
 
 ;;; @ for mime-edit
@@ -264,8 +258,7 @@ it is used as hook to set."
 	(let ((key
 	       (or (cdr (assq major-mode mime-setup-signature-key-alist))
 		   mime-setup-default-signature-key)))
-	  (define-key keymap key (function insert-signature))
-	  ))))
+	  (define-key keymap key (function insert-signature))))))
 
 (when mime-setup-use-signature
   (add-hook 'mime-edit-mode-hook 'mime-setup-set-signature-key)
@@ -290,8 +283,7 @@ it is used as hook to set."
 	'((type . application)
 	  (method . mime-mac-save-and-play-with-open))
 	'with-default
-	"mime-mac")
-       )))
+	"mime-mac"))))
 
 
 ;;; @ end

--- a/signature.el
+++ b/signature.el
@@ -82,8 +82,7 @@ FIELD, the contents of FILENAME is inserted.")
             (concat "^" (regexp-quote mail-header-separator) "$")
             nil t)
            (match-beginning 0)
-         (point-max)
-         ))
+         (point-max)))
       (catch 'found
         (let ((alist signature-file-alist) cell field value)
           (while alist
@@ -94,8 +93,7 @@ FIELD, the contents of FILENAME is inserted.")
 		   (let ((name (apply value field (cdr cell))))
 		     (if name
 			 (throw 'found
-				(concat signature-file-prefix name))
-		       )))
+				(concat signature-file-prefix name)))))
 		  ((stringp field)
 		   (cond ((consp value)
 			  (while value
@@ -103,16 +101,13 @@ FIELD, the contents of FILENAME is inserted.")
 				(throw 'found
 				       (concat
 					signature-file-prefix (cdr cell)))
-			      (setq value (cdr value))
-			      )))
+			      (setq value (cdr value)))))
 			 ((stringp value)
 			  (if (string-match value field)
 			      (throw 'found
 				     (concat
-				      signature-file-prefix (cdr cell)))
-			    )))))
-            (setq alist (cdr alist))
-            ))
+				      signature-file-prefix (cdr cell))))))))
+            (setq alist (cdr alist))))
         signature-file-name))))
 
 (defun insert-signature (&optional arg)
@@ -125,20 +120,17 @@ specify a file named <signature-file-name>-DISTRIBUTION interactively."
          (expand-file-name
           (or (and arg
 		   (signature/get-sigtype-interactively))
-	      (signature/get-signature-file-name))
-          )))
+	      (signature/get-signature-file-name)))))
     (or (file-readable-p signature-file-name)
         (error "Cannot open signature file: %s" signature-file-name))
     (if signature-insert-at-eof
         (progn
           (goto-char (point-max))
           (or (bolp) (insert "\n"))
-          (if signature-delete-blank-lines-at-eof (delete-blank-lines))
-          ))
+          (if signature-delete-blank-lines-at-eof (delete-blank-lines))))
     (run-hooks 'signature-insert-hook)
     (if (= (point)(point-max))
-	(insert signature-separator)
-      )
+	(insert signature-separator))
     (insert-file-contents signature-file-name)
     (force-mode-line-update)
     signature-file-name))


### PR DESCRIPTION
Fix closing parens position.
[Package-lint](https://github.com/purcell/package-lint) warns your package
> Closing parens should not be wrapped onto new lines. (emacs-lisp-package)

I eval below sexp in dired (depends `visual-regexp`).

``` emacs-lisp
(while (dired-get-filename nil 'no-error)
  (let ((file (dired-get-filename)))
    (with-temp-file file
      (insert-file-contents file)

      (while (not (= 0 (vr/replace "^(?!.*;)(.*)\\n[\\s\\t]*(\\)+)" "\\1\\2" (point-min) (point-max))))))
    (message file)
    (dired-next-line 1)))
```