### PR TITLE
Added variable to suppress confirmation when inserting files.

### DIFF
--- a/mime-edit.el
+++ b/mime-edit.el
@@ -164,6 +164,11 @@ If non-nil, the text tag is not inserted unless something different."
   :group 'mime-edit
   :type 'boolean)
 
+(defcustom mime-edit-insert-file-confirm t
+  "*Confirm guessed mime type when inserting files."
+  :group 'mime-edit
+  :type 'boolean)
+
 (defcustom mime-edit-voice-recorder
   (function mime-edit-voice-recorder-for-sun)
   "*Function to record a voice message and encode it."
@@ -1563,7 +1568,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	  (disposition-type (nth 4 guess))
 	  (disposition-params (nth 5 guess))
 	  )
-    (setq verbose (or (interactive-p) verbose))
+    (setq verbose (or (and (interactive-p) mime-edit-insert-file-confirm) verbose))
     (if verbose
 	(setq type (mime-prompt-for-type type)
 	      subtype (mime-prompt-for-subtype type subtype)
@@ -1590,7 +1595,7 @@ If optional argument SUBTYPE is not nil, text/SUBTYPE tag is inserted."
 	  (disposition-type (nth 4 guess))
 	  (disposition-params (nth 5 guess))
 	  )
-    (setq verbose (or (interactive-p) verbose))
+    (setq verbose (or (and (interactive-p) mime-edit-insert-file-confirm) verbose))
     (if verbose
 	(setq subtype (mime-prompt-for-subtype type subtype)))
     (setq parameters


### PR DESCRIPTION
When inserting files, mime-edit confirms the guessed mime types, subtypes and disposition. When
inserting many files, this can be annoying. I've added the variable `mime-edit-insert-file-confirm'
that allows supressing this behavior. It can always be reenabled by passing a prefix argument to `mime-edit-insert-file(-as-text)'.