### PR TITLE
Don't split a large message by default

### DIFF
--- a/mime-edit.el
+++ b/mime-edit.el
@@ -797,7 +797,7 @@ Each elements are regexp of field-name.")
 ;;; @@ about message splitting
 ;;;
 
-(defcustom mime-edit-split-message t
+(defcustom mime-edit-split-message nil
   "*Split large message if it is non-nil."
   :group 'mime-edit
   :type 'boolean)


### PR DESCRIPTION
* mime-edit.el (mime-edit-split-message): Set to nil.

This prevents unintentional splitting, that has been used since 2002
in Debian.  cf. https://packages.qa.debian.org/s/semi/news/20020424T020224Z.html
