### PR TITLE
Declare bbdb-vcard as a dependency

### DIFF
--- a/semi-pkg.el
+++ b/semi-pkg.el
@@ -2,4 +2,5 @@
   "A library to provide MIME features."
   '((emacs "24.5")
     (apel "10.8")
+    (bbdb-vcard "0.4.1")
     (flim "1.14.9")))


### PR DESCRIPTION
bbdb-vcard has been a dependency since
b1c245b81715b0430f7593cee2339e6264104f3d.  However, it is not declared so in semi-pkg.el.
* semi-pkg.el: Declare bbdb-vcard as a dependency.


ref: https://github.com/NixOS/nixpkgs/issues/335442